### PR TITLE
feat: Accounting Receipt from Issue

### DIFF
--- a/phamos/hooks.py
+++ b/phamos/hooks.py
@@ -32,6 +32,7 @@ required_apps = ["erpnext"]
 
 # include js in doctype views
 doctype_js = {"Project" : "public/js/project.js"}
+doctype_js = {"Issue" : "public/js/issue.js"}
 # doctype_js = {"doctype" : "public/js/doctype.js"}
 # doctype_list_js = {"doctype" : "public/js/doctype_list.js"}
 # doctype_tree_js = {"doctype" : "public/js/doctype_tree.js"}

--- a/phamos/phamos/doctype/accounting_receipt/accounting_receipt.py
+++ b/phamos/phamos/doctype/accounting_receipt/accounting_receipt.py
@@ -2,9 +2,12 @@
 # For license information, please see license.txt
 
 import frappe
+from frappe import _
 from frappe.model.document import Document
 from frappe.utils import today
 from erpnext import get_default_company
+from frappe.desk.form.load import get_attachments, get_communications
+from frappe.desk.form.utils import add_comment
 
 
 class AccountingReceipt(Document):
@@ -35,3 +38,38 @@ class AccountingReceipt(Document):
 		pi.insert()
 		self.db_set('purchase_invoice', pi.name)
 		return pi
+
+
+@frappe.whitelist()
+def make_accounting_receipt(issue):
+	"""
+		Create an Accouting Receipt from an Issue
+	"""
+	issue_doc = frappe.get_doc("Issue",issue)
+	ar = frappe.new_doc("Accounting Receipt")
+	ar.posting_date = today()
+	ar.customer = issue_doc.customer
+	ar.project = issue_doc.project
+	ar.title = issue_doc.subject
+	ar.conversion_rate = 1
+	ar.insert()
+	issue_doc.db_set("accounting_receipt", ar.name)
+
+	""" Get the email data and attachments """
+	communication_data = get_communications("Issue",issue)
+	for data in communication_data:
+		content = data.content
+		attachments = frappe.get_all(
+		"File",
+		fields=["name"],
+		filters={"attached_to_name": "Communication", "attached_to_doctype": data.name},
+		)
+		""" Transfer the attachments """
+		if attachments := [d.name for d in get_attachments("Communication",data.name)]:
+			for attachment in attachments:
+				file_doc = frappe.get_doc("File",attachment)
+				file_doc.db_set("attached_to_doctype", "Accounting Receipt")
+				file_doc.db_set("attached_to_name", ar.name)
+		"""" Add email as Comment """		
+		ar.add_comment("Comment", content)
+	return ar.name

--- a/phamos/public/js/issue.js
+++ b/phamos/public/js/issue.js
@@ -1,0 +1,17 @@
+frappe.ui.form.on("Issue", {
+	refresh: function (frm) {
+        if (!frm.doc.accounting_receipt) {
+            frm.add_custom_button(__('Accounting Receipt'), () => {
+                    frappe.call({
+                        method: "phamos.phamos.doctype.accounting_receipt.accounting_receipt.make_accounting_receipt",
+                        args: {
+                            issue: frm.doc.name
+                        },
+                        callback(r){
+                            frappe.set_route('Form', 'Accounting Receipt', r.message)
+                        }
+                    })
+            }, __("Create"));
+	    }
+}
+});


### PR DESCRIPTION
https://github.com/phamos-eu/phamos/issues/1

- Added button Create -> Accounting Receipt in Issue
- Copies over Subject as title, Customer, Project
- Adds email communication as comment in Accounting Receipt
- Attachments are transferred from email to attachments in Accounting Receipt
- Added field in reference section on Issue for Accounting Receipt
- And added condition if Accounting Receipt reference exists, button will not show

![Monosnap screencast 2023-12-14 22-41-00](https://github.com/phamos-eu/phamos/assets/16913064/d919430a-75cb-49f5-bde3-67717395dce3)
@wojosc @roquegv @beingeek Please review