### PR TITLE
Hide activity_doctype and actvity_docname and delete column_break_zgqwu in Timesheet Record

### DIFF
--- a/phamos/phamos/doctype/timesheet_record/timesheet_record.json
+++ b/phamos/phamos/doctype/timesheet_record/timesheet_record.json
@@ -16,7 +16,6 @@
   "expected_time",
   "to_time",
   "actual_time",
-  "column_break_zgqwu",
   "timesheet",
   "activity_doctype",
   "activity_docname",
@@ -94,10 +93,6 @@
    "read_only": 1
   },
   {
-   "fieldname": "column_break_zgqwu",
-   "fieldtype": "Column Break"
-  },
-  {
    "fieldname": "timesheet",
    "fieldtype": "Link",
    "label": "Timesheet",
@@ -108,12 +103,14 @@
   {
    "fieldname": "activity_doctype",
    "fieldtype": "Link",
+   "hidden": 1,
    "label": "Activity Doctype",
    "options": "DocType"
   },
   {
    "fieldname": "activity_docname",
    "fieldtype": "Dynamic Link",
+   "hidden": 1,
    "label": "Activity Docname",
    "options": "activity_doctype"
   },
@@ -166,7 +163,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-02-26 23:15:34.892920",
+ "modified": "2024-02-27 09:15:34.892920",
  "modified_by": "Administrator",
  "module": "Phamos",
  "name": "Timesheet Record",


### PR DESCRIPTION
**Goal:** 
Delete `activity_doctype` and `activity_docname`, and merge `percent_billable` into the same column as `from_time` and `expected_time`. 
Instead of immediate deletion, we'll initially hide `activity_doctype` and `activity_docname`. After a few weeks, we'll finally delete them. 
The `column_break_zgqwu` has been removed.

Start state with changes in red:
![Start state with changes in red](https://github.com/phamos-eu/phamos/assets/103729772/46d0e581-4cba-4191-a211-3cb45f6d71a3)

Desired outcome:
<img width="896" alt="image" src="https://github.com/phamos-eu/phamos/assets/103729772/91e049f5-cf60-4cde-9ca7-f2a5c27dbf72">

