### PR TITLE
feat:sort as per timesheet record , devided in 3 column start dialog …

### DIFF
--- a/phamos/phamos/number_card/total_projects/total_projects.json
+++ b/phamos/phamos/number_card/total_projects/total_projects.json
@@ -1,0 +1,22 @@
+{
+ "creation": "2024-04-16 11:55:30.853210",
+ "docstatus": 0,
+ "doctype": "Number Card",
+ "dynamic_filters_json": "",
+ "filters_json": "null",
+ "function": "Count",
+ "idx": 0,
+ "is_public": 1,
+ "is_standard": 1,
+ "label": "Total Projects",
+ "method": "phamos.phamos.page.project_action_panel.project_action_panel.get_project_count",
+ "modified": "2024-04-16 11:55:30.853210",
+ "modified_by": "sonalinarkar121@gmail.com",
+ "module": "Phamos",
+ "name": "Total Projects",
+ "owner": "sonalinarkar121@gmail.com",
+ "report_function": "Sum",
+ "show_percentage_stats": 1,
+ "stats_time_interval": "Daily",
+ "type": "Custom"
+}

--- a/phamos/phamos/phamos_dashboard/project_management/project_management.json
+++ b/phamos/phamos/phamos_dashboard/project_management/project_management.json
@@ -1,0 +1,25 @@
+{
+ "cards": [
+  {
+   "card": "Total Projects"
+  }
+ ],
+ "charts": [
+  {
+   "chart": "Project Summary",
+   "width": "Half"
+  }
+ ],
+ "creation": "2024-04-15 18:27:11.940763",
+ "dashboard_name": "Project Management",
+ "docstatus": 0,
+ "doctype": "Dashboard",
+ "idx": 0,
+ "is_default": 0,
+ "is_standard": 1,
+ "modified": "2024-04-16 11:55:53.442183",
+ "modified_by": "sonalinarkar121@gmail.com",
+ "module": "Phamos",
+ "name": "Project Management",
+ "owner": "Administrator"
+}


### PR DESCRIPTION
sort as per timesheet record , devided in 3 column start dialog box, dashboard and number card added

<img width="1261" alt="Screenshot 2024-04-16 at 14 44 36" src="https://github.com/phamos-eu/phamos/assets/61533913/865acd0a-8e65-41e0-941e-79440c0b4cfe">

<img width="1226" alt="Screenshot 2024-04-16 at 14 44 10" src="https://github.com/phamos-eu/phamos/assets/61533913/4ee57856-ee64-4ee9-95d4-583e7f3a10fe">

<img width="1238" alt="Screenshot 2024-04-16 at 11 51 15" src="https://github.com/phamos-eu/phamos/assets/61533913/85b09fdb-4d38-4b80-961d-eb12321bd55f">
