### PR TITLE
add percent_billable field ,change location of button 'Timesheet Calender View'

### DIFF
--- a/phamos/patches.txt
+++ b/phamos/patches.txt
@@ -1,3 +1,3 @@
 phamos.patches.v1_0.add_custom_fields_for_employee #123
 phamos.patches.v1_0.add_property_for_timesheet_record #12334567
-phamos.patches.v1_0.add_custom_fields_for_project #123
+phamos.patches.v1_0.add_custom_fields_for_project #1234567

--- a/phamos/patches/v1_0/add_custom_fields_for_project.py
+++ b/phamos/patches/v1_0/add_custom_fields_for_project.py
@@ -14,8 +14,18 @@ def execute():
 		fieldtype="Data",
 		insert_after="phamos_section_break"))
     
-    
+    create_custom_field("project",
+    	dict(fieldname="phamos_columns_break", label="",
+		fieldtype="Column Break", insert_after="planned_hours"
+    ))
+
+    create_custom_field("project",
+        dict(fieldname="percent_billable", label="Percent Billable",
+		fieldtype="Select",
+		options="\n0\n25\n50\n75\n100",insert_after="phamos_columns_break",default = 100
+		))
+
     create_custom_field("project",
 	    dict(fieldname="phamos_section_break_end", label="",
-		fieldtype="Section Break", insert_after="planned_hours"))
+		fieldtype="Section Break", insert_after="percent_billable"))
     

--- a/phamos/phamos/page/project_action_panel/project_action_panel.py
+++ b/phamos/phamos/page/project_action_panel/project_action_panel.py
@@ -104,7 +104,7 @@ def fetch_projects():
     # Custom SQL query to fetch project data
     employee_name = frappe.db.get_value("Employee", {"user_id": frappe.session.user}, "name")
     projects = frappe.db.sql("""
-        SELECT p.name AS name, p.planned_hours AS planned_hours, p.status AS status, p.notes AS notes, p.project_name AS project_name, CONCAT(p.name, " - ", p.project_name) AS project_desc,
+        SELECT p.percent_billable as percent_billable ,p.name AS name, p.planned_hours AS planned_hours, p.status AS status, p.notes AS notes, p.project_name AS project_name, CONCAT(p.name, " - ", p.project_name) AS project_desc,
         ROUND((SELECT SUM(t.total_hours) FROM `tabTimesheet` t 
         WHERE t.docstatus = 0 AND t.name IN (SELECT td.parent FROM `tabTimesheet Detail` td WHERE td.project = p.name)), 3) AS spent_hours_draft,
         ROUND((SELECT SUM(t.total_hours) FROM `tabTimesheet` t 


### PR DESCRIPTION
1. Add a "percent_billable" field in the Project, with a default value of 100.

<img width="1256" alt="Screenshot 2024-05-10 at 13 34 01" src="https://github.com/phamos-eu/phamos/assets/61533913/e034bef7-8218-4fc4-b0f1-c5139bf12c18">

2. Fetch the "percent_billable" field to the Project Action Panel.

<img width="1242" alt="Screenshot 2024-05-10 at 13 35 34" src="https://github.com/phamos-eu/phamos/assets/61533913/70ea14d2-c128-4819-9dcd-a1366302f044">

3. Relocate the "Timesheet Calendar View" button.
<img width="1258" alt="Screenshot 2024-05-10 at 13 36 30" src="https://github.com/phamos-eu/phamos/assets/61533913/dba98855-50fe-427f-aedc-fbb8d2fb3fa1">

4. Minimize the font size of 'Project Action Panel'.

<img width="1260" alt="Screenshot 2024-05-10 at 13 37 52" src="https://github.com/phamos-eu/phamos/assets/61533913/79249b14-d289-4a07-9aab-e242a7434ff4">
