### PR TITLE
feat:remove default time from start and stop window , update draft an…

### DIFF
--- a/phamos/phamos/page/project_action_panel/project_action_panel.js
+++ b/phamos/phamos/page/project_action_panel/project_action_panel.js
@@ -142,7 +142,7 @@ frappe.pages['project-action-panel'].on_page_load = function(wrapper) {
                             label: 'Time',
                             fieldname: 'to_time',
                             fieldtype: 'Datetime',
-                            default: frappe.datetime.now_datetime(), reqd: 1
+                            reqd: 1
                         },
                        
                         {
@@ -182,6 +182,7 @@ frappe.pages['project-action-panel'].on_page_load = function(wrapper) {
                     primary_action(values) {
                         update_and_submit_timesheet_record(values.timesheet_record,values.to_time,values.percent_billable,values.activity_type,values.result)
                         dialog.hide();
+                        window.location.reload();
                     }
                     
                 });
@@ -192,7 +193,7 @@ frappe.pages['project-action-panel'].on_page_load = function(wrapper) {
 
         });
 
-      
+       
     };
      //return record.timesheet_record_draft;
 
@@ -258,7 +259,6 @@ frappe.pages['project-action-panel'].on_page_load = function(wrapper) {
                                         in_list_view: 1,
                                         reqd: 1,
                                         read_only:0,
-                                        default: frappe.datetime.now_datetime()
                                     },
                                     {
                                         fieldtype: 'Column Break'

--- a/phamos/phamos/page/project_action_panel/project_action_panel.py
+++ b/phamos/phamos/page/project_action_panel/project_action_panel.py
@@ -106,9 +106,9 @@ def fetch_projects():
     projects = frappe.db.sql("""
         SELECT p.percent_billable as percent_billable ,p.name AS name, p.planned_hours AS planned_hours, p.status AS status, p.notes AS notes, p.project_name AS project_name, CONCAT(p.name, " - ", p.project_name) AS project_desc,
         ROUND((SELECT SUM(t.total_hours) FROM `tabTimesheet` t 
-        WHERE t.docstatus = 0 AND t.name IN (SELECT td.parent FROM `tabTimesheet Detail` td WHERE td.project = p.name)), 3) AS spent_hours_draft,
+        WHERE t.docstatus = 0 and t.employee = %(employee)s AND t.name IN (SELECT td.parent FROM `tabTimesheet Detail` td WHERE td.project = p.name)), 3) AS spent_hours_draft,
         ROUND((SELECT SUM(t.total_hours) FROM `tabTimesheet` t 
-        WHERE t.docstatus = 1 AND t.name IN (SELECT td.parent FROM `tabTimesheet Detail` td WHERE td.project = p.name)), 3) AS spent_hours_submitted,
+        WHERE t.docstatus = 1 and t.employee = %(employee)s AND t.name IN (SELECT td.parent FROM `tabTimesheet Detail` td WHERE td.project = p.name)), 3) AS spent_hours_submitted,
         (SELECT name FROM `tabCustomer` c WHERE p.customer = c.name) AS customer,
         (SELECT CASE WHEN c.name != c.customer_name THEN CONCAT(c.name, " - ", c.customer_name) ELSE c.customer_name END FROM `tabCustomer` c WHERE p.customer = c.name) AS customer_desc,
         (SELECT max(ts.name) FROM `tabTimesheet Record` ts WHERE ts.project = p.name AND ts.employee = %(employee)s AND ts.docstatus = 0) AS timesheet_record


### PR DESCRIPTION
1. "Remove default time from the 'Time' field in the 'Start' and 'Stop' dialog windows."

<img width="1232" alt="Screenshot 2024-05-27 at 13 55 13" src="https://github.com/phamos-eu/phamos/assets/61533913/6cf56029-d1c0-4315-9ce7-ee99dce8d72c">

<img width="1215" alt="Screenshot 2024-05-27 at 13 55 59" src="https://github.com/phamos-eu/phamos/assets/61533913/8c3096b1-c8d7-4aef-917f-869f5c43a4d9">


3. show 'Spent Draft Hrs' and 'Spent Submitted Hrs' of the employee which is connected to the logged in user.

<img width="1227" alt="Screenshot 2024-05-27 at 13 54 56" src="https://github.com/phamos-eu/phamos/assets/61533913/954a6302-8ca8-4b3f-834f-fcde8b2fb40e">
