### PR TITLE
PHAMOS#31 - PDF Preview of Document

### DIFF
--- a/phamos/phamos/doctype/accounting_receipt/accounting_receipt.js
+++ b/phamos/phamos/doctype/accounting_receipt/accounting_receipt.js
@@ -54,7 +54,49 @@ frappe.ui.form.on("Accounting Receipt", {
                 );
                 frm.page.set_inner_btn_group_as_primary(__("Create"));
         }
+
+        // Hide PDF Preview if no attachment available or display it onload of document 
+        frm.toggle_display("pdf_preview", false);
+        frm.trigger("attachment");
     },
+
+    attachment: function (frm) {
+        /* on attachment of PDF document in attachment field in doclevel
+            system will generate a preview of the attached document
+        */
+        let $preview = "";
+        let file_extension = frm.events.getFileExtension(frm.doc.attachment);
+
+        if (file_extension === "pdf") {
+            $preview = $(`<div class="img_preview">
+                <h2 style="
+                        font-size: var(--text-lg);   
+                        font-weight: var(--weight-semibold);
+                        letter-spacing: .015em;
+                        color: var(--text-color);
+                        cursor: default;"> PDF Preview</h2>
+				<object style="background:#323639;" width="100%">
+					<embed
+						style="background:#323639;"
+						width="100%"
+						height="600px"
+						src="${frappe.utils.escape_html(frm.doc.attachment)}" type="application/pdf"
+					>
+				</object>
+			</div>`);
+        }
+
+        if ($preview) {
+            frm.toggle_display("pdf_preview", true);
+            frm.get_field("pdf_preview").$wrapper.html($preview);
+        }
+    },
+
+    getFileExtension: function (filename) {
+        // Get extension of the file
+        return filename.split('.').pop();
+    },
+
     make_purchase_invoice: function (frm) {
         return frappe.call({
             method: "make_purchase_invoice",

--- a/phamos/phamos/doctype/accounting_receipt/accounting_receipt.json
+++ b/phamos/phamos/doctype/accounting_receipt/accounting_receipt.json
@@ -20,6 +20,7 @@
   "currency",
   "conversion_rate",
   "column_break_9lcf0",
+  "pdf_preview",
   "note",
   "purchase_section_section",
   "supplier",
@@ -333,6 +334,11 @@
    "fieldtype": "Link",
    "label": "Item",
    "options": "Item"
+  },
+  {
+   "fieldname": "pdf_preview",
+   "fieldtype": "HTML",
+   "label": "PDF Preview"
   }
  ],
  "index_web_pages_for_search": 1,
@@ -355,7 +361,7 @@
    "link_fieldname": "accounting_receipt"
   }
  ],
- "modified": "2023-11-06 19:28:28.423884",
+ "modified": "2024-05-28 15:05:36.281984",
  "modified_by": "Administrator",
  "module": "Phamos",
  "name": "Accounting Receipt",


### PR DESCRIPTION
### NOTE :  MIGRATION REQUIRED

### Points Covered In This PR
_In this PR we have added a functionality that will give preview of the attached PDF document in the attachment field in doclevel, to acheive this task we have added some changes which are mentioned below._
- Added html field name **_PDF Preview_** in **Accounting Receipt** doctype level
- Added a functionality that will show the preview of the PDF document.
- <img width="1378" alt="Screenshot 2024-05-28 at 16 56 48" src="https://github.com/phamos-eu/phamos/assets/14124603/845aeab6-1f90-4dc8-b240-d41ea210b1d1">
- ![recording-pdfpreview](https://github.com/phamos-eu/phamos/assets/14124603/a45356a2-588a-40fb-aa68-1dfceec97153)

