### PR TITLE
feat:minimize reload time of project action panel

### DIFF
--- a/phamos/phamos/page/project_action_panel/project_action_panel.js
+++ b/phamos/phamos/page/project_action_panel/project_action_panel.js
@@ -8,20 +8,23 @@ frappe.pages['project-action-panel'].on_page_load = function(wrapper) {
     if (wrapper.page) {
         wrapper.page.set_title('<span style="font-size: 14px;">Project Action Panel</span>');
     }
-
-    // Fetch project data from the server on page load
-    frappe.call({
-        method: "phamos.phamos.page.project_action_panel.project_action_panel.fetch_projects",
-        callback: function(r) {
-            if (r.message) {
-                // Render DataTable with the fetched data
-                renderDataTable(wrapper, r.message);
-                //console.log(window.location.href)
-            } else {
-                // Handle error or empty data
+    
+    function render_datatable(){
+        frappe.call({
+            method: "phamos.phamos.page.project_action_panel.project_action_panel.fetch_projects",
+            callback: function(r) {
+                if (r.message) {
+                    // Render DataTable with the fetched data
+                    renderDataTable(wrapper, r.message);
+                    //console.log(window.location.href)
+                } else {
+                    // Handle error or empty data
+                }
             }
-        }
-    });
+        });
+    }
+    // Fetch project data from the server on page load
+    render_datatable()
    
     // Function to create timesheet record
     function create_timesheet_record(project_name,customer,from_time,expected_time,goal){
@@ -40,11 +43,12 @@ frappe.pages['project-action-panel'].on_page_load = function(wrapper) {
 				if(r.message) {
                     let doc = frappe.model.sync(r.message);
 					frappe.msgprint('Timesheet Record: '+doc[0].name+' Created Successfully.');
-                    reloadPage();
+                    render_datatable()
 					}
 				}
         })
-        window.location.reload();
+        
+       
     }
 
     // Function to create timesheet record
@@ -64,11 +68,12 @@ frappe.pages['project-action-panel'].on_page_load = function(wrapper) {
 				if(r.message) {
                     let doc = frappe.model.sync(r.message);
 					frappe.msgprint('Timesheet Record: '+doc[0].name+' Updated Successfully.');
-                    reloadPage();
+                    render_datatable()
 					}
 				}
         })
-        window.location.reload();
+        
+        
     }
 
     window.handleCustomerClick = function(customer_name) {
@@ -102,9 +107,7 @@ frappe.pages['project-action-panel'].on_page_load = function(wrapper) {
     
     
 
-    function reloadPage() {
-        window.location.href = window.location.href.split('?')[0]; // Reload the page without parameters
-    }
+   
     
     window.stopProject = function(timesheet_record,percent_billable) {
         let activity_type = ""
@@ -182,7 +185,7 @@ frappe.pages['project-action-panel'].on_page_load = function(wrapper) {
                     primary_action(values) {
                         update_and_submit_timesheet_record(values.timesheet_record,values.to_time,values.percent_billable,values.activity_type,values.result)
                         dialog.hide();
-                        window.location.reload();
+                        
                     }
                     
                 });


### PR DESCRIPTION
1. Program added to reload only the DataTable instead of the whole page.

2. After submitting the 'Start' button dialog box, the DataTable will reload, and you will see the updated data.

<img width="1220" alt="Screenshot 2024-05-31 at 14 30 19" src="https://github.com/phamos-eu/phamos/assets/61533913/0262b0af-63a5-450b-913e-ed3e211a191b">

3. After submitting the 'Stop' button dialog box, the DataTable will reload, and you will see the updated data.

<img width="1226" alt="Screenshot 2024-05-31 at 14 32 43" src="https://github.com/phamos-eu/phamos/assets/61533913/2726f50a-fc61-481e-9086-1dadb97e8d2c">

