### PR TITLE
feat:add msg after start and stop dialog box

### DIFF
--- a/phamos/phamos/doctype/timesheet_record/timesheet_record.py
+++ b/phamos/phamos/doctype/timesheet_record/timesheet_record.py
@@ -46,7 +46,8 @@ class TimesheetRecord(Document):
 		)
 		timesheet.insert()
 		self.db_set('timesheet', timesheet.name)
-		frappe.msgprint(_('Timesheet {0} Created').format(frappe.get_desk_link("Timesheet", timesheet.name)))
+		
+		frappe.msgprint(_('Make sure to provide the issue number, chat link from Mattermost, and your solution. Note that this information will be shared with the customer via the timesheet record.<br><br>Timesheet {0} Created').format(frappe.get_desk_link("Timesheet", timesheet.name)))
 
 @frappe.whitelist()
 def set_actual_time(from_time, to_time):

--- a/phamos/phamos/doctype/timesheet_record/timesheet_record.py
+++ b/phamos/phamos/doctype/timesheet_record/timesheet_record.py
@@ -47,7 +47,7 @@ class TimesheetRecord(Document):
 		timesheet.insert()
 		self.db_set('timesheet', timesheet.name)
 		
-		frappe.msgprint(_('Make sure to provide the issue number, chat link from Mattermost, and your solution. Note that this information will be shared with the customer via the timesheet record.<br><br>Timesheet {0} Created').format(frappe.get_desk_link("Timesheet", timesheet.name)))
+		frappe.msgprint(_('Timesheet {0} Created').format(frappe.get_desk_link("Timesheet", timesheet.name)))
 
 @frappe.whitelist()
 def set_actual_time(from_time, to_time):

--- a/phamos/phamos/page/project_action_panel/project_action_panel.js
+++ b/phamos/phamos/page/project_action_panel/project_action_panel.js
@@ -178,7 +178,7 @@ frappe.pages['project-action-panel'].on_page_load = function(wrapper) {
                             label: 'What I did ',
                             fieldname: 'result',
                             fieldtype: 'Small Text', reqd: 1,
-                            description:"⚠️ Important: Make sure to provide the issue number, chat link from Mattermost, and your solution. Note that this information will be shared with the customer via the timesheet record."
+                            description:"⚠️ This information is sent to the customer next day. Please make sure to wright meaningful text. Adding Issues ID's and or URL is helpful."
                         },
                         
                     ],
@@ -281,7 +281,7 @@ frappe.pages['project-action-panel'].on_page_load = function(wrapper) {
                                         fieldname: "goal",
                                         in_list_view: 1,
                                         reqd: 1,
-                                        description : "⚠️ Important: Make sure to provide the issue number, chat link from Mattermost, and your Goal. Note that this information will be shared with the customer via the timesheet record."
+                                        description : "⚠️ User this to manifest on what you are working and going to do. This will be shared with the customer next day."
                                     },
                                 ],
                                 primary_action_label: __("Create Timesheet Record."),

--- a/phamos/phamos/page/project_action_panel/project_action_panel.js
+++ b/phamos/phamos/page/project_action_panel/project_action_panel.js
@@ -67,7 +67,7 @@ frappe.pages['project-action-panel'].on_page_load = function(wrapper) {
 			callback: function(r) {
 				if(r.message) {
                     let doc = frappe.model.sync(r.message);
-					frappe.msgprint('Timesheet Record: '+doc[0].name+' Updated Successfully.');
+                    frappe.msgprint('Make sure to provide the issue number, chat link from Mattermost, and your solution. Note that this information will be shared with the customer via the timesheet record.<br><br>Timesheet Record: ' + doc[0].name + ' Updated Successfully.');
                     render_datatable()
 					}
 				}
@@ -188,6 +188,7 @@ frappe.pages['project-action-panel'].on_page_load = function(wrapper) {
                         
                     }
                     
+                    
                 });
                 // Set the width using CSS
                 dialog.$wrapper.find('.modal-dialog').css('max-width', '900px');
@@ -285,12 +286,14 @@ frappe.pages['project-action-panel'].on_page_load = function(wrapper) {
                                 primary_action(values) {
                                     create_timesheet_record(values.project_name,values.customer,values.from_time,values.expected_time,values.goal)
                                     dialog.hide();  
+                                    frappe.msgprint('Make sure to provide the issue number, chat link from Mattermost, and your goal. Note that this information will be shared with the customer via the timesheet record.')
                                 }
                             });
                             
                             // Set the width using CSS
                             dialog.$wrapper.find('.modal-dialog').css('max-width', '800px');
                             dialog.show();
+                            
                         
                     }
                 } else {

--- a/phamos/phamos/page/project_action_panel/project_action_panel.js
+++ b/phamos/phamos/page/project_action_panel/project_action_panel.js
@@ -67,7 +67,7 @@ frappe.pages['project-action-panel'].on_page_load = function(wrapper) {
 			callback: function(r) {
 				if(r.message) {
                     let doc = frappe.model.sync(r.message);
-                    frappe.msgprint('Make sure to provide the issue number, chat link from Mattermost, and your solution. Note that this information will be shared with the customer via the timesheet record.<br><br>Timesheet Record: ' + doc[0].name + ' Updated Successfully.');
+                    frappe.msgprint('Timesheet Record: ' + doc[0].name + ' Updated Successfully.');
                     render_datatable()
 					}
 				}
@@ -177,7 +177,8 @@ frappe.pages['project-action-panel'].on_page_load = function(wrapper) {
                         {
                             label: 'What I did ',
                             fieldname: 'result',
-                            fieldtype: 'Small Text', reqd: 1
+                            fieldtype: 'Small Text', reqd: 1,
+                            description:"⚠️ Important: Make sure to provide the issue number, chat link from Mattermost, and your solution. Note that this information will be shared with the customer via the timesheet record."
                         },
                         
                     ],
@@ -279,14 +280,14 @@ frappe.pages['project-action-panel'].on_page_load = function(wrapper) {
                                         label: __("Goal"),
                                         fieldname: "goal",
                                         in_list_view: 1,
-                                        reqd: 1
+                                        reqd: 1,
+                                        description : "⚠️ Important: Make sure to provide the issue number, chat link from Mattermost, and your Goal. Note that this information will be shared with the customer via the timesheet record."
                                     },
                                 ],
                                 primary_action_label: __("Create Timesheet Record."),
                                 primary_action(values) {
                                     create_timesheet_record(values.project_name,values.customer,values.from_time,values.expected_time,values.goal)
                                     dialog.hide();  
-                                    frappe.msgprint('Make sure to provide the issue number, chat link from Mattermost, and your goal. Note that this information will be shared with the customer via the timesheet record.')
                                 }
                             });
                             


### PR DESCRIPTION
1. Description added to 'Goal' field in Start Dialog box.

<img width="1222" alt="Screenshot 2024-06-12 at 18 42 51" src="https://github.com/phamos-eu/phamos/assets/61533913/2203f76a-80eb-4924-9fa3-dacf6ad3fe4d">

2. Description added to 'What I did' field in Stop Dialog box.

<img width="1228" alt="Screenshot 2024-06-12 at 18 43 25" src="https://github.com/phamos-eu/phamos/assets/61533913/4463edde-606a-4e59-ae3b-f3616226a3c4">
