### PR TITLE
feature/33-adding-doctype-implementation-with-field-notes-to-app

### DIFF
--- a/phamos/phamos/doctype/implementation/implementation.js
+++ b/phamos/phamos/doctype/implementation/implementation.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2024, phamos.eu and contributors
+// For license information, please see license.txt
+
+// frappe.ui.form.on("Implementation", {
+// 	refresh(frm) {
+
+// 	},
+// });

--- a/phamos/phamos/doctype/implementation/implementation.json
+++ b/phamos/phamos/doctype/implementation/implementation.json
@@ -1,0 +1,46 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2024-06-25 16:22:04.571926",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "notes",
+  "column_break_zpwc"
+ ],
+ "fields": [
+  {
+   "fieldname": "notes",
+   "fieldtype": "Text Editor",
+   "label": "Notes"
+  },
+  {
+   "fieldname": "column_break_zpwc",
+   "fieldtype": "Column Break"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2024-06-25 16:24:00.209439",
+ "modified_by": "Administrator",
+ "module": "Phamos",
+ "name": "Implementation",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "sort_field": "creation",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/phamos/phamos/doctype/implementation/implementation.py
+++ b/phamos/phamos/doctype/implementation/implementation.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2024, phamos.eu and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class Implementation(Document):
+	pass

--- a/phamos/phamos/doctype/implementation/test_implementation.py
+++ b/phamos/phamos/doctype/implementation/test_implementation.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2024, phamos.eu and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestImplementation(FrappeTestCase):
+	pass


### PR DESCRIPTION
Added the Doctype Implementation, with one (1) field, named "notes".
<img width="1138" alt="image" src="https://github.com/phamos-eu/phamos/assets/103729772/4a517ba4-8059-463b-9cb5-51d68a2429f0">

Links:
Related Mattermost threads: 
https://chat.phamos.eu/phamos/pl/5ofimfucet848nrwamx4kdannr
https://chat.phamos.eu/phamos/pl/jnzwpxz6piyzdmobgiite477ia

Related GitLab Issues:
https://git.phamos.eu/phamos/phamos/-/issues/25
