### PR TITLE
Update Mattermost Channel in phamos Settings

### DIFF
--- a/phamos/custom_scripts/custom_python/mattermost_daily_thread.py
+++ b/phamos/custom_scripts/custom_python/mattermost_daily_thread.py
@@ -81,10 +81,17 @@ def create_mattermost_thread():
     """
 
     thought_of_the_day = get_thought_of_the_day()
+    channel_ids = frappe.db.sql("""
+        select channel_id from `tabMattermost Channel` where enable = %s
+    """,{1}, as_dict=True)
 
-    channel_id = "dgwi7scxd7by5nj6nqyt19b7po"  # Replace with your Mattermost channel ID
+    if channel_ids:
+        channel_id = channel_ids[0]['channel_id']  # Replace with your Mattermost channel ID
+    else:
+        return    
+    
     #reply_message = "Good Morning 'phamos'"
-    reply_message = f"Good Morning 'phamos'💮\n > {thought_of_the_day}🌟"
+    reply_message = f"Good Morning 'phamos' 💮 🙏\n > {thought_of_the_day}🌟"
    
 
     # Post the initial message with today's date and "Daily"

--- a/phamos/custom_scripts/custom_python/thoughtOftheDay.txt
+++ b/phamos/custom_scripts/custom_python/thoughtOftheDay.txt
@@ -301,11 +301,6 @@
 "The past cannot be changed. The future is yet in your power."
 "To see what is right and not do it is the want of courage."
 "The purpose of our lives is to be happy."
-"Do
-next 100 pls
-ChatGPT
-Sure, here are the next 100 thoughts:
-
 "Do not wait to strike till the iron is hot, but make it hot by striking."
 "Life is 10% what happens to us and 90% how we react to it."
 "There is no greater disability in society than the inability to see a person as more."

--- a/phamos/phamos/doctype/mattermost_channel/mattermost_channel.json
+++ b/phamos/phamos/doctype/mattermost_channel/mattermost_channel.json
@@ -1,0 +1,46 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2024-07-26 09:49:11.926407",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "channel",
+  "channel_id",
+  "enable"
+ ],
+ "fields": [
+  {
+   "fieldname": "channel",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Channel"
+  },
+  {
+   "fieldname": "channel_id",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Channel ID"
+  },
+  {
+   "default": "0",
+   "fieldname": "enable",
+   "fieldtype": "Check",
+   "in_list_view": 1,
+   "label": "Enable"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2024-07-26 09:53:29.254403",
+ "modified_by": "Administrator",
+ "module": "Phamos",
+ "name": "Mattermost Channel",
+ "owner": "Administrator",
+ "permissions": [],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/phamos/phamos/doctype/mattermost_channel/mattermost_channel.py
+++ b/phamos/phamos/doctype/mattermost_channel/mattermost_channel.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2024, phamos.eu and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class MattermostChannel(Document):
+	pass

--- a/phamos/phamos/doctype/phamos_settings/phamos_settings.js
+++ b/phamos/phamos/doctype/phamos_settings/phamos_settings.js
@@ -5,4 +5,18 @@ frappe.ui.form.on('phamos Settings', {
 	// refresh: function(frm) {
 
 	// }
+
+});
+frappe.ui.form.on('phamos Settings', {
+    validate: function(frm) {
+        // Filter out the enabled channels
+        let enabled_channels = frm.doc.mattermost_channel.filter(channel => channel.enable);
+
+        // Check if more than one channel is enabled
+        if (enabled_channels.length > 1) {
+            frappe.msgprint(__('Only one Mattermost Channel can be enabled at a time.'));
+            // Prevent the form from being saved
+            frappe.validated = false;
+        }
+    }
 });

--- a/phamos/phamos/doctype/phamos_settings/phamos_settings.json
+++ b/phamos/phamos/doctype/phamos_settings/phamos_settings.json
@@ -14,7 +14,9 @@
   "is_employee_feedback",
   "mattermost_daily_thread_settings_tab",
   "enable_daily_thread_creation",
-  "thread_posting_hour"
+  "thread_posting_hour",
+  "section_break_s3bt",
+  "mattermost_channel"
  ],
  "fields": [
   {
@@ -61,12 +63,22 @@
    "fieldtype": "Select",
    "label": "Thread Posting Hour",
    "options": "\n1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n11\n12\n13\n14\n15\n16\n17\n18\n19\n20\n21\n22\n23"
+  },
+  {
+   "fieldname": "section_break_s3bt",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "mattermost_channel",
+   "fieldtype": "Table",
+   "label": "Select Channel to Create Daily Thread",
+   "options": "Mattermost Channel"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2024-07-16 15:58:39.752336",
+ "modified": "2024-07-26 09:50:48.727495",
  "modified_by": "Administrator",
  "module": "Phamos",
  "name": "phamos Settings",


### PR DESCRIPTION
1. Add a child table named 'Mattermost Channel' to the 'Phamos Settings' table.

<img width="1210" alt="Screenshot 2024-07-26 at 10 56 21" src="https://github.com/user-attachments/assets/f98b7a68-a1d8-4fae-9837-a0b97b80fad9">

2. Validation added: Only one Mattermost Channel can be enabled at a time.

<img width="1194" alt="Screenshot 2024-07-26 at 10 57 54" src="https://github.com/user-attachments/assets/4917f747-d23e-42c7-bc55-fd9aa4c5f911">

3. A thread will be created in the enabled channel at the selected time.

<img width="1199" alt="Screenshot 2024-07-26 at 10 58 55" src="https://github.com/user-attachments/assets/d6e6fde2-a64c-470a-9154-e48e50eb53fc">
