### PR TITLE
feat:add task in project action panel

### DIFF
--- a/phamos/phamos/page/project_action_panel/project_action_panel.js
+++ b/phamos/phamos/page/project_action_panel/project_action_panel.js
@@ -32,6 +32,7 @@ frappe.pages["project-action-panel"].on_page_load = function (wrapper) {
   // Function to create timesheet record
   function create_timesheet_record(
     project_name,
+    task,
     customer,
     from_time,
     expected_time,
@@ -42,6 +43,7 @@ frappe.pages["project-action-panel"].on_page_load = function (wrapper) {
         "phamos.phamos.page.project_action_panel.project_action_panel.create_timesheet_record",
       args: {
         project_name: project_name,
+        task:task,
         customer: customer,
         from_time: from_time,
         expected_time: expected_time,
@@ -136,7 +138,7 @@ frappe.pages["project-action-panel"].on_page_load = function (wrapper) {
     return false;
   };
 
-  window.stopProject = function (timesheet_record, percent_billable) {
+  window.stopProject = function (timesheet_record, percent_billable,task) {
     let activity_type = "";
     let timesheet_record_info = " Info from timesheet record";
     frappe.db.get_value(
@@ -164,6 +166,14 @@ frappe.pages["project-action-panel"].on_page_load = function (wrapper) {
                   in_list_view: 1,
                   read_only: 1,
                   default: timesheet_record,
+                },
+                {
+                  fieldtype: "Link",
+                  label: __("Task"),
+                  fieldname: "task",
+                  in_list_view: 1,
+                  read_only: 1,
+                  default: task,
                 },
                 {
                   fieldtype: "Small Text",
@@ -242,7 +252,7 @@ frappe.pages["project-action-panel"].on_page_load = function (wrapper) {
   };
   //return record.timesheet_record_draft;
 
-  window.startProject = function (project_name, customer) {
+  window.startProject = function (project_name, customer,project) {
     frappe.call({
       method:
         "phamos.phamos.page.project_action_panel.project_action_panel.check_draft_timesheet_record",
@@ -306,6 +316,24 @@ frappe.pages["project-action-panel"].on_page_load = function (wrapper) {
                   default: project_name,
                 },
                 {
+                  fieldtype: "Link",
+                  options: "Task",
+                  label: __("Task"),
+                  fieldname: "task",
+                  in_list_view: 1,
+                  read_only: 0,
+                  get_query: function() {
+                      if (project) {
+                          return {
+                              filters: {
+                                  project: project
+                              }
+                          };
+                      } else {
+                          return {};
+                      }
+                  }},
+                {
                   fieldtype: "Data",
                   options: "Customer",
                   label: __("Customer"),
@@ -347,6 +375,7 @@ frappe.pages["project-action-panel"].on_page_load = function (wrapper) {
               primary_action(values) {
                 create_timesheet_record(
                   values.project_name,
+                  values.task,
                   values.customer,
                   values.from_time,
                   values.expected_time,
@@ -424,9 +453,9 @@ frappe.pages["project-action-panel"].on_page_load = function (wrapper) {
     let button_formatter = (value, row) => {
       // Now that both project and employee values are available, you can render the button
       if (row[8].html == "") {
-        return `<button type="button" style="height: 23px; width: 60px; display: flex; align-items: center; justify-content: center; background-color: rgb(0, 100, 0);" class="btn btn-primary btn-sm btn-modal-primary" onclick="startProject('${row[1].content}', '${row[3].content}')">Start</button>`;
+        return `<button type="button" style="height: 23px; width: 60px; display: flex; align-items: center; justify-content: center; background-color: rgb(0, 100, 0);" class="btn btn-primary btn-sm btn-modal-primary" onclick="startProject('${row[1].content}', '${row[3].content}', '${row[9].content}')">Start</button>`;
       } else {
-        return `<button type="button" style="height: 23px; width: 60px; display: flex; align-items: center; justify-content: center; background-color: rgb(139, 0, 0);" class="btn btn-primary btn-sm btn-modal-primary" onclick="stopProject('${row[8].content}','${row[11].content}')">Stop</button>`;
+        return `<button type="button" style="height: 23px; width: 60px; display: flex; align-items: center; justify-content: center; background-color: rgb(139, 0, 0);" class="btn btn-primary btn-sm btn-modal-primary" onclick="stopProject('${row[8].content}','${row[11].content}','${row[12].content}')">Stop</button>`;
       }
     };
 
@@ -512,6 +541,13 @@ frappe.pages["project-action-panel"].on_page_load = function (wrapper) {
         width: 0,
         editable: false,
       },
+      {
+        label: "<b>Task</b>",
+        id: "task",
+        fieldtype: "Link",
+        width: 0,
+        editable: false,
+      },
     ];
     function linkFormatter1(value, row, columnId) {
       return `<a href="#" onclick="handleProjectClick('${row[9].content}');">${row[2].content}</a>`;
@@ -570,6 +606,17 @@ frappe.pages["project-action-panel"].on_page_load = function (wrapper) {
     styleHeader_pb.innerHTML =
       ".dt-cell__content--header-11 { display: none; }"; // Change dt-cell__content dt-cell__content--header-4 to dt-cell__content--header-3
     document.head.appendChild(styleHeader_pb);
+
+    // Add a style element to hide the "task" column cells
+    let style_t = document.createElement("style");
+    style_t.innerHTML = ".dt-cell__content--col-12 { display: none; }";
+    document.head.appendChild(style_t);
+
+    // Add a style element to hide the "percent_billable" column header
+    let styleHeader_t = document.createElement("style");
+    styleHeader_t.innerHTML =
+      ".dt-cell__content--header-12 { display: none; }"; // Change dt-cell__content dt-cell__content--header-4 to dt-cell__content--header-3
+    document.head.appendChild(styleHeader_t);
 
     // Add a header to the report view
     //wrapper.innerHTML = `<h1>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Project Action Panel </h1></div><div id="card-wrapper"></div><div id="datatable-wrapper"></div>`;

--- a/phamos/phamos/page/project_action_panel/project_action_panel.py
+++ b/phamos/phamos/page/project_action_panel/project_action_panel.py
@@ -7,7 +7,7 @@ from datetime import datetime
 from datetime import datetime, timedelta
 
 @frappe.whitelist()
-def create_timesheet_record(project_name, customer, from_time, expected_time, goal):
+def create_timesheet_record(project_name, task, customer, from_time, expected_time, goal):
     try:
         employee_name = frappe.db.get_value("Employee", {"user_id": frappe.session.user}, "name")
         activity_type = frappe.db.get_value("Employee", {"user_id": frappe.session.user}, "activity_type")
@@ -19,6 +19,7 @@ def create_timesheet_record(project_name, customer, from_time, expected_time, go
             
             timesheet_record = frappe.new_doc('Timesheet Record')
             timesheet_record.project = project
+            timesheet_record.task=task
             timesheet_record.customer = customer
             timesheet_record.from_time = after_1_minute
             timesheet_record.expected_time = expected_time
@@ -113,7 +114,8 @@ def fetch_projects():
         WHERE t.docstatus = 1 and t.employee = %(employee)s AND t.name IN (SELECT td.parent FROM `tabTimesheet Detail` td WHERE td.project = p.name)), 3) AS spent_hours_submitted,
         (SELECT name FROM `tabCustomer` c WHERE p.customer = c.name) AS customer,
         (SELECT CASE WHEN c.name != c.customer_name THEN CONCAT(c.name, " - ", c.customer_name) ELSE c.customer_name END FROM `tabCustomer` c WHERE p.customer = c.name) AS customer_desc,
-        (SELECT max(ts.name) FROM `tabTimesheet Record` ts WHERE ts.project = p.name AND ts.employee = %(employee)s AND ts.docstatus = 0) AS timesheet_record
+        (SELECT max(ts.name) FROM `tabTimesheet Record` ts WHERE ts.project = p.name AND ts.employee = %(employee)s AND ts.docstatus = 0) AS timesheet_record,
+        (SELECT (ts1.task) FROM `tabTimesheet Record` ts1 WHERE ts1.name = (SELECT max(ts.name) FROM `tabTimesheet Record` ts WHERE ts.project = p.name AND ts.employee = %(employee)s AND ts.docstatus = 0)) AS task
         FROM `tabProject` p
         WHERE (SELECT max(reference_name) FROM `tabToDo` td WHERE td.status = "Open" AND td.reference_name = p.name AND td.allocated_to = %(user)s) IS NOT NULL
         ORDER BY timesheet_record IS NULL, timesheet_record ASC  # Show records with timesheet_record first


### PR DESCRIPTION
In Project Action Panel:

Add a Task field in the Start Dialog Box on the Project Action Panel page.

The Task should be a link field.
Add a filter to the Task field to show only tasks related to the selected project.
Save the selected Task in the Timesheet record.

<img width="1100" alt="Screenshot 2024-09-23 at 22 50 01" src="https://github.com/user-attachments/assets/c20c2e6b-1123-4a3f-9e49-64d1f6a1f3f7">
<img width="1257" alt="Screenshot 2024-09-23 at 22 51 17" src="https://github.com/user-attachments/assets/c9f571ae-7b85-486f-aad9-796e4e4cd141">
<img width="1119" alt="Screenshot 2024-09-23 at 22 51 42" src="https://github.com/user-attachments/assets/0f29cd13-7bd5-4e02-9141-885e3d667392">
