### PR TITLE
Update Task visibility in Project and in Project Action Panel

### DIFF
--- a/phamos/patches.txt
+++ b/phamos/patches.txt
@@ -1,3 +1,3 @@
 phamos.patches.v1_0.add_custom_fields_for_employee #1235
 phamos.patches.v1_0.add_property_for_timesheet_record #12334567
-phamos.patches.v1_0.add_custom_fields_for_project #12345678
+phamos.patches.v1_0.add_custom_fields_for_project #123456789

--- a/phamos/patches/v1_0/add_custom_fields_for_project.py
+++ b/phamos/patches/v1_0/add_custom_fields_for_project.py
@@ -29,3 +29,21 @@ def execute():
 	    dict(fieldname="phamos_section_break_end", label="",
 		fieldtype="Section Break", insert_after="percent_billable"))
     
+    create_custom_field("project",
+	    dict(fieldname="phamos_column_break_end", label="",
+		fieldtype="Column Break", insert_after="percent_billable"))
+    
+    create_custom_field(
+        "Project",
+        dict(
+            fieldname="task_in_timesheet_record",    
+            label="Task in timesheet record",       
+            fieldtype="Select",                     
+            options="\nTask is hidden\nTask is optional\nTask is mandatory",   
+            insert_after="phamos_column_break_end",   
+            default="Task is hidden"   
+        )
+    )
+    
+	
+    

--- a/phamos/phamos/page/project_action_panel/project_action_panel.py
+++ b/phamos/phamos/page/project_action_panel/project_action_panel.py
@@ -108,7 +108,7 @@ def fetch_projects():
     # Custom SQL query to fetch project data
     employee_name = frappe.db.get_value("Employee", {"user_id": frappe.session.user}, "name")
     projects = frappe.db.sql("""
-        SELECT p.percent_billable as percent_billable ,p.name AS name, p.planned_hours AS planned_hours, p.status AS status, p.notes AS notes, p.project_name AS project_name, CONCAT(p.name, " - ", p.project_name) AS project_desc,
+        SELECT p.percent_billable as percent_billable ,p.name AS name, p.planned_hours AS planned_hours,p.task_in_timesheet_record, p.status AS status, p.notes AS notes, p.project_name AS project_name, CONCAT(p.name, " - ", p.project_name) AS project_desc,
         ROUND((SELECT SUM(t.total_hours) FROM `tabTimesheet` t 
         WHERE t.docstatus = 0 and t.employee = %(employee)s AND t.name IN (SELECT td.parent FROM `tabTimesheet Detail` td WHERE td.project = p.name)), 3) AS spent_hours_draft,
         ROUND((SELECT SUM(t.total_hours) FROM `tabTimesheet` t 
@@ -130,7 +130,7 @@ def fetch_all_projects():
     # Custom SQL query to fetch project data
     employee_name = frappe.db.get_value("Employee", {"user_id": frappe.session.user}, "name")
     projects = frappe.db.sql("""
-        SELECT p.percent_billable as percent_billable ,p.name AS name, p.planned_hours AS planned_hours, p.status AS status, p.notes AS notes, p.project_name AS project_name, CONCAT(p.name, " - ", p.project_name) AS project_desc,
+        SELECT p.percent_billable as percent_billable ,p.name AS name, p.planned_hours AS planned_hours,p.task_in_timesheet_record, p.status AS status, p.notes AS notes, p.project_name AS project_name, CONCAT(p.name, " - ", p.project_name) AS project_desc,
         ROUND((SELECT SUM(t.total_hours) FROM `tabTimesheet` t 
         WHERE t.docstatus = 0 and t.employee = %(employee)s AND t.name IN (SELECT td.parent FROM `tabTimesheet Detail` td WHERE td.project = p.name)), 3) AS spent_hours_draft,
         ROUND((SELECT SUM(t.total_hours) FROM `tabTimesheet` t 


### PR DESCRIPTION
[#67](https://git.phamos.eu/phamos/phamos/-/issues/67) Add a task selection when clocking time on Project Action Panel

https://chat.phamos.eu/phamos/pl/66wpz9ew3bdb3mihdernmq63zc

1. Create the task_in_timesheet_record Field in the Project Doctype:

Add a new field named task_in_timesheet_record in the Project doctype.
Set the field type to Select with the following options:
Task is hidden
Task is optional
Task is mandatory
Set the default value of the field to Task is hidden.

2. Fetch task_in_timesheet_record Field in the Project Action Panel:

In the Project Action Panel, fetch the value of the task_in_timesheet_record field from the related Project.

3. Dynamically Update Task Field in Start/Stop Dialog Box:

In the Start/Stop dialog box for timesheet entries, dynamically update the Task field based on the fetched value from the Project doctype of task_in_timesheet_record.
If the value is Task is hidden, hide the Task field in the dialog.
If the value is Task is optional, make the Task field optional for users to fill.
If the value is Task is mandatory, make the Task field required for users to proceed.
Tested the Functionality on local Instance.










