### PR TITLE
feat:add validation to avoid duplocation of daily thread creation

### DIFF
--- a/phamos/phamos/doctype/phamos_settings/phamos_settings.json
+++ b/phamos/phamos/doctype/phamos_settings/phamos_settings.json
@@ -17,6 +17,7 @@
   "mattermost_daily_thread_settings_tab",
   "enable_daily_thread_creation",
   "thread_posting_hour",
+  "last_daily_thread_creation_date",
   "section_break_s3bt",
   "mattermost_channel"
  ],
@@ -85,12 +86,17 @@
    "fieldname": "enable_feedback_dialog",
    "fieldtype": "Check",
    "label": "Enable Feedback Dialog"
+  },
+  {
+   "fieldname": "last_daily_thread_creation_date",
+   "fieldtype": "Date",
+   "label": "Last Daily Thread Creation Date"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2024-08-27 09:51:53.829234",
+ "modified": "2024-10-04 15:48:25.774179",
  "modified_by": "Administrator",
  "module": "Phamos",
  "name": "phamos Settings",


### PR DESCRIPTION
✅ Daily Message via API ✅ 

https://chat.phamos.eu/phamos/pl/doh97u7p7jdpf8fyp1z56fo83c

Add a "Last Daily Thread Creation Date" field in phamos Settings.

Update today's date to "Last Daily Thread Creation" after creating a thread.

If the system attempts to create a thread again, add a validation to check if "Last Daily Thread Creation" matches today's date. If it does, the thread will not be created.

<img width="1251" alt="Screenshot 2024-10-04 at 15 51 17" src="https://github.com/user-attachments/assets/0f4d729b-5e7c-42c2-872e-429d3e1636df">

