### PR TITLE
add colors to hours header and rows

### DIFF
--- a/phamos/phamos/page/project_action_panel/project_action_panel.js
+++ b/phamos/phamos/page/project_action_panel/project_action_panel.js
@@ -522,8 +522,6 @@ function render_cards(wrapper, card_names) {
   });
 }
 
-
-
 // Function to render DataTable with tabs
 function renderDataTable(wrapper, projectData) {
  // Ensure wrapper is defined
@@ -533,7 +531,10 @@ function renderDataTable(wrapper, projectData) {
 
 // Set the default active tab to 'Your Projects'
 wrapper.innerHTML = `
-<h2 style="display: inline; margin-left: 50px; margin-top: 10px; font-size:30px">Project Action Panel</h2>
+<h2 style="display: inline; margin-left: 50px; margin-top: 10px; font-size:30px">
+    Project Action Panel
+    <!-- Info Icon -->
+</h2>
 <div class="form-tabs-list">
     <ul class="nav form-tabs" id="form-tabs" role="tablist">
         <li class="nav-item show">
@@ -555,6 +556,44 @@ wrapper.innerHTML = `
     <div id="datatable-wrapper"></div>
 </div>
 `;
+// Add CSS for the hover-over box
+const tooltipStyle = document.createElement("style");
+tooltipStyle.innerHTML = `
+  #info-icon {
+    position: relative;
+    cursor: pointer;
+  }
+
+  #info-icon:hover::after {
+    content: "Label Descriptions:\\A Red Color = Planned Hrs\\A Orange Color = Spent Draft Hrs\\A Green Color = Spent Submitted Hrs";
+    white-space: pre-wrap;
+    position: absolute;
+    left: 50%;
+    top: 100%;
+    transform: translateX(-50%);
+    padding: 15px;
+    background-color: rgba(0, 0, 0, 0.8);
+    color: white;
+    border-radius: 5px;
+    font-size: 12px;
+    line-height: 1.5;
+    z-index: 1000;
+    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+    width: 250px;
+  }
+`;
+document.head.appendChild(tooltipStyle);
+
+// Add the info icon with hover functionality
+const infoIcon = document.createElement("span");
+infoIcon.id = "info-icon";
+infoIcon.innerHTML = "ℹ️"; // Info icon text or HTML (e.g., an SVG or font icon)
+infoIcon.style.fontSize = "20px";
+infoIcon.style.marginLeft = "10px";
+
+// Append the info icon next to the title
+const header = document.querySelector("h2");
+header.appendChild(infoIcon);
 
 // Get references to the tabs
 const your_projectsTab = document.getElementById("DAP-your-project-tab");
@@ -596,7 +635,6 @@ show_tab("Your Projects", projectData); // Set 'Your Projects' as default
 function show_tab(tab, projectData) {
 const cardWrapper = document.getElementById("card-wrapper");
 const datatableWrapper = document.getElementById("datatable-wrapper");
-
 // Clear previous content of cardWrapper and datatableWrapper
 cardWrapper.innerHTML = "";  // This will ensure the number cards don't duplicate
 datatableWrapper.innerHTML = ""; // Clear previous DataTable content
@@ -673,12 +711,12 @@ function renderProjectDataTable(datatableWrapper, projectData) {
 
   let columns = [
     { label: "<b>Project Name</b>", id: "project_name", fieldtype: "Data", width: 180, editable: false, visible: false },
-    { label: "<b>Project</b>", id: "project_desc", fieldtype: "Data", width: 200, editable: false, format: linkFormatter1 },
+    { label: "<b>Project</b>", id: "project_desc", fieldtype: "Data", width: 362, editable: false, format: linkFormatter1 },
     { label: "<b>Customer Name</b>", id: "customer", fieldtype: "Link", width: 120, editable: false },
-    { label: "<b>Customer</b>", id: "customer_desc", fieldtype: "Link", width: 180, editable: false, format: linkFormatter },
-    { label: "<b>Planned Hrs</b>", id: "planned_hours", fieldtype: "Data", width: 110, editable: false },
-    { label: "<b>Spent Draft Hrs</b>", id: "spent_hours_draft", fieldtype: "Float", width: 140, editable: false },
-    { label: "<b>Spent Submitted Hrs</b>", id: "spent_hours_submitted", fieldtype: "Float", width: 180, editable: false },
+    { label: "<b>Customer</b>", id: "customer_desc", fieldtype: "Link", width: 362, editable: false, format: linkFormatter },
+    { label: "<b></b>", id: "planned_hours", fieldtype: "Data", width: 70, editable: false },
+    { label: "<b></b>", id: "spent_hours_draft", fieldtype: "Float", width: 70, editable: false },
+    { label: "<b></b>", id: "spent_hours_submitted", fieldtype: "Float", width: 70, editable: false },
     { label: "<b>Timesheet Record</b>", id: "timesheet_record", fieldtype: "Link", width: 160, editable: false, format: linkFormatter2 },
     { label: "<b>Name</b>", id: "name", fieldtype: "Link", width: 140, editable: false },
     { label: "<b>Action</b>", focusable: false, format: button_formatter, width: 100 },
@@ -690,13 +728,9 @@ function renderProjectDataTable(datatableWrapper, projectData) {
       focusable: false, 
       format: button_formatter1, 
       width: 120 
-  }
-  
-
-  
+    }
   ];
   
-
   function linkFormatter1(value, row) {
     return `<a href="#" onclick="handleProjectClick('${row[9].content}');">${row[2].content}</a>`;
   }
@@ -726,7 +760,28 @@ style.innerHTML = `
 
   /* Hide the "task_in_timesheet_record" column cells and header */
   .dt-cell__content--col-13, .dt-cell__content--header-13 { display: none; }
-  
+
+  .dt-cell__content--col-5 {
+    color: #f28b82; 
+  }
+  .dt-cell__content--header-5 {
+    background-color: #f28b82 !important;
+    color: white;
+  }
+  .dt-cell__content--col-6 {
+    color: #FFA500; 
+  }
+  .dt-cell__content--header-6 {
+    background-color: #FFA500 !important; 
+    color: white;
+  }
+  .dt-cell__content--col-7 {
+    color: #A4D3B4; /* Light pastel orange for text */
+  }
+  .dt-cell__content--header-7 {
+    background-color: #A4D3B4 !important; 
+    color: white; 
+  }
 `;
 document.head.appendChild(style);
 


### PR DESCRIPTION
upgrade the UI/UX of the Project Action Panel

https://git.phamos.eu/phamos/phamos/-/work_items/97#note_10356

add colors to hours headers and rows.
<img width="1259" alt="Screenshot 2024-12-03 at 10 12 16" src="https://github.com/user-attachments/assets/ddb2dcc7-19a4-410d-a3be-0ab037ede85d">
<img width="772" alt="Screenshot 2024-12-03 at 10 12 30" src="https://github.com/user-attachments/assets/84385817-6059-44ac-98f4-782b33ddcf0a">
<img width="1272" alt="Screenshot 2024-12-03 at 10 18 01" src="https://github.com/user-attachments/assets/f3d9cd13-3fad-44e0-b60a-622aefc24b72">
