### PR TITLE
Update project action panel 1

### DIFF
--- a/phamos/phamos/page/project_action_panel/project_action_panel.js
+++ b/phamos/phamos/page/project_action_panel/project_action_panel.js
@@ -281,29 +281,49 @@ frappe.pages["project-action-panel"].on_page_load = function (wrapper) {
                       const minutes = Math.floor((seconds % 3600) / 60);
                       return `${hours} hrs ${minutes} mins`;
                     }
-                    const confirm_msg = 
-                      `Expected time is: ${formatTime(expected_time)} and actual work is: ${formatTime(r.message)}. Please review and confirm.`;
-                    frappe.confirm(
-                      confirm_msg,
-                      function () {
-                        // If user clicks "Yes"
-                        update_and_submit_timesheet_record(
-                          values.timesheet_record,
-                          values.task,
-                          values.to_time,
-                          values.percent_billable,
-                          values.activity_type,
-                          values.result
-                        );
-                        dialog.hide();
-      
-                      },
-                      function () {
-                        // If user clicks "No"
-                        //frappe.msgprint('You clicked No!');
-                        // Cancel the action here or do nothing
-                      }
-                    );
+                    
+                    const expectedHours = expected_time / 3600;
+                    const actualHours = r.message / 3600;
+                    const diffInHours = actualHours - expectedHours;
+                    if (diffInHours > 0.5) { // More than 30 minutes
+                      const message = `Actual work is more than 30 minutes above the expected time. Please review and confirm.`;
+                      const confirm_msg = `
+                        Expected time is: ${formatTime(expected_time)} and actual work is: ${formatTime(r.message)}. 
+                        ${message}
+                      `; 
+                      frappe.confirm(
+                        confirm_msg,
+                        function () {
+                          // If user clicks "Yes"
+                          update_and_submit_timesheet_record(
+                            values.timesheet_record,
+                            values.task,
+                            values.to_time,
+                            values.percent_billable,
+                            values.activity_type,
+                            values.result
+                          );
+                          dialog.hide();
+        
+                        },
+                        function () {
+                          // If user clicks "No"
+                          //frappe.msgprint('You clicked No!');
+                          // Cancel the action here or do nothing
+                        }
+                      );
+                    }
+                    else{
+                      update_and_submit_timesheet_record(
+                        values.timesheet_record,
+                        values.task,
+                        values.to_time,
+                        values.percent_billable,
+                        values.activity_type,
+                        values.result
+                      );
+                      dialog.hide();
+                    }
                   }
                 }
               });

--- a/phamos/phamos/page/project_action_panel/project_action_panel.py
+++ b/phamos/phamos/page/project_action_panel/project_action_panel.py
@@ -291,3 +291,9 @@ def format_duration(duration_in_seconds):
 		return f"{minutes} Mins"
 	else:
 		return f"{seconds} Secs"
+
+
+@frappe.whitelist()
+def set_actual_time(from_time, to_time):
+	if from_time and to_time:
+		return time_diff_in_seconds(to_time, from_time)


### PR DESCRIPTION
https://git.phamos.eu/phamos/phamos/-/work_items/90

ToDo - add Frappe Confirm Dialog validation on 'update timesheet record' button.

Most of time user adds 'end date and time' wrong. Prompt user to recheck and correct it before submitting timesheet record, if timesheet actual working time exceeds more than 30 mins than expected time. 

<img width="1018" alt="Screenshot 2025-01-08 at 11 43 33" src="https://github.com/user-attachments/assets/b8cffe16-698d-4d5c-bbc3-48c8efab52f9" />
<img width="1069" alt="Screenshot 2025-01-08 at 11 44 41" src="https://github.com/user-attachments/assets/2cca3958-1f65-48b4-8420-9f42985cbad1" />
