### PR TITLE
Add and Track Implementation Doctype to the phamos app

### DIFF
--- a/phamos/phamos/doctype/implementation/implementation.js
+++ b/phamos/phamos/doctype/implementation/implementation.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2025, phamos.eu and contributors
+// For license information, please see license.txt
+
+// frappe.ui.form.on("Implementation", {
+// 	refresh(frm) {
+
+// 	},
+// });

--- a/phamos/phamos/doctype/implementation/implementation.json
+++ b/phamos/phamos/doctype/implementation/implementation.json
@@ -41,6 +41,7 @@
    "in_preview": 1,
    "in_standard_filter": 1,
    "label": "Account Manager",
+   "link_filters": "[[\"User\",\"role\",\"=\",\"Accounts Manager\"]]",
    "options": "User"
   },
   {
@@ -62,6 +63,7 @@
    "fieldname": "forecast",
    "fieldtype": "Select",
    "in_list_view": 1,
+   "in_preview": 1,
    "in_standard_filter": 1,
    "label": "Forecast",
    "options": "1 \u2600\ufe0f - alles gut. Kunde happy, keine Gefahren (deadlines, Erwartung an Stunden etc) in sicht\n2 \ud83c\udf24\ufe0f - zu viele neue Issues, feedback langsam\n3 \u2601\ufe0f - weekly findet nicht jede Woche statt, Kundenprojektmanager schwer zu erreichen,\n4 \ud83c\udf27\ufe0f - Anforderungen \u00e4ndern sich sehr h\u00e4ufig, Weeklies werden nicht wahrgenommen, kunde antwortet auf Mails nicht\n5 \u26c8\ufe0f - Kunde zahlt Rechnungen nicht, Kunde hat keine Gedult"
@@ -100,7 +102,7 @@
    "link_fieldname": "custom_implementation"
   }
  ],
- "modified": "2025-01-08 19:04:30.694249",
+ "modified": "2025-01-09 18:04:12.431440",
  "modified_by": "Administrator",
  "module": "Phamos",
  "name": "Implementation",

--- a/phamos/phamos/doctype/implementation/implementation.json
+++ b/phamos/phamos/doctype/implementation/implementation.json
@@ -1,0 +1,98 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "autoname": "field:customer",
+ "creation": "2025-01-08 08:50:32.532515",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "notes",
+  "start_date",
+  "column_break_ifue",
+  "account_manager",
+  "customer_information_section",
+  "customer",
+  "contact_person",
+  "tab_2_tab"
+ ],
+ "fields": [
+  {
+   "fieldname": "notes",
+   "fieldtype": "Text Editor",
+   "in_list_view": 1,
+   "label": "Notes",
+   "reqd": 1
+  },
+  {
+   "fieldname": "column_break_ifue",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "account_manager",
+   "fieldtype": "Link",
+   "label": "Account Manager",
+   "link_filters": "[[\"User\",\"role\",\"=\",\"Accounts Manager\"]]",
+   "options": "User"
+  },
+  {
+   "fieldname": "start_date",
+   "fieldtype": "Date",
+   "label": "Start Date"
+  },
+  {
+   "fieldname": "customer_information_section",
+   "fieldtype": "Section Break",
+   "label": "Customer Information"
+  },
+  {
+   "fieldname": "customer",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Customer",
+   "options": "Customer",
+   "reqd": 1,
+   "unique": 1
+  },
+  {
+   "fieldname": "tab_2_tab",
+   "fieldtype": "Tab Break",
+   "label": "Timesheets"
+  },
+  {
+   "fieldname": "contact_person",
+   "fieldtype": "Link",
+   "label": "Contact Person",
+   "options": "User"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "links": [
+  {
+   "link_doctype": "Project",
+   "link_fieldname": "name"
+  }
+ ],
+ "modified": "2025-01-08 09:28:32.740763",
+ "modified_by": "Administrator",
+ "module": "Phamos",
+ "name": "Implementation",
+ "naming_rule": "By fieldname",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/phamos/phamos/doctype/implementation/implementation.json
+++ b/phamos/phamos/doctype/implementation/implementation.json
@@ -1,38 +1,29 @@
 {
  "actions": [],
  "allow_rename": 1,
- "autoname": "field:customer",
- "creation": "2025-01-08 08:50:32.532515",
+ "autoname": "prompt",
+ "creation": "2025-01-08 18:25:12.851586",
  "doctype": "DocType",
  "engine": "InnoDB",
  "field_order": [
   "notes",
   "start_date",
-  "column_break_ifue",
+  "column_break_7p95",
   "account_manager",
-  "customer_information_section",
+  "maturity_level",
+  "mood",
+  "forecast",
+  "section_break_ky9b",
   "customer",
   "contact_person",
-  "tab_2_tab"
+  "timesheets_tab",
+  "html_bfhi"
  ],
  "fields": [
   {
    "fieldname": "notes",
    "fieldtype": "Text Editor",
-   "in_list_view": 1,
-   "label": "Notes",
-   "reqd": 1
-  },
-  {
-   "fieldname": "column_break_ifue",
-   "fieldtype": "Column Break"
-  },
-  {
-   "fieldname": "account_manager",
-   "fieldtype": "Link",
-   "label": "Account Manager",
-   "link_filters": "[[\"User\",\"role\",\"=\",\"Accounts Manager\"]]",
-   "options": "User"
+   "label": "Notes"
   },
   {
    "fieldname": "start_date",
@@ -40,43 +31,80 @@
    "label": "Start Date"
   },
   {
-   "fieldname": "customer_information_section",
+   "fieldname": "column_break_7p95",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "account_manager",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "in_preview": 1,
+   "in_standard_filter": 1,
+   "label": "Account Manager",
+   "options": "User"
+  },
+  {
+   "fieldname": "maturity_level",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "in_preview": 1,
+   "in_standard_filter": 1,
+   "label": "Maturity Level",
+   "options": "1 - Start der Implementierung, keine Vorerfahrung, noch kein\n2 - Poweruser kann sich orientieren,\n3 - Live-Betrieb, Erste Module sind im Einsatz,\n4 - Erste Module abgeschlossen, Entwicklungsprozesse in der Tiefe verstanden,\n5 - Quasi-abgeschlossen, System ist implementiert, Viele geschulte Anwender, hoher Automatisierungsgrad,"
+  },
+  {
+   "fieldname": "mood",
+   "fieldtype": "Select",
+   "label": "Mood",
+   "options": "1\n2\n3\n4\n5"
+  },
+  {
+   "fieldname": "forecast",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Forecast",
+   "options": "1 \u2600\ufe0f - alles gut. Kunde happy, keine Gefahren (deadlines, Erwartung an Stunden etc) in sicht\n2 \ud83c\udf24\ufe0f - zu viele neue Issues, feedback langsam\n3 \u2601\ufe0f - weekly findet nicht jede Woche statt, Kundenprojektmanager schwer zu erreichen,\n4 \ud83c\udf27\ufe0f - Anforderungen \u00e4ndern sich sehr h\u00e4ufig, Weeklies werden nicht wahrgenommen, kunde antwortet auf Mails nicht\n5 \u26c8\ufe0f - Kunde zahlt Rechnungen nicht, Kunde hat keine Gedult"
+  },
+  {
+   "fieldname": "section_break_ky9b",
    "fieldtype": "Section Break",
    "label": "Customer Information"
   },
   {
    "fieldname": "customer",
    "fieldtype": "Link",
-   "in_list_view": 1,
    "label": "Customer",
-   "options": "Customer",
-   "reqd": 1,
-   "unique": 1
+   "options": "Customer"
   },
   {
-   "fieldname": "tab_2_tab",
+   "fieldname": "contact_person",
+   "fieldtype": "Data",
+   "label": "Contact Person"
+  },
+  {
+   "fieldname": "timesheets_tab",
    "fieldtype": "Tab Break",
    "label": "Timesheets"
   },
   {
-   "fieldname": "contact_person",
-   "fieldtype": "Link",
-   "label": "Contact Person",
-   "options": "User"
+   "fieldname": "html_bfhi",
+   "fieldtype": "HTML",
+   "options": "<h1>Info</h1>On this screen we will want to see a table of all timesheets from this implmentation. Interesting also will be some filters for project, employee, and more"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [
   {
    "link_doctype": "Project",
-   "link_fieldname": "name"
+   "link_fieldname": "custom_implementation"
   }
  ],
- "modified": "2025-01-08 09:28:32.740763",
+ "modified": "2025-01-08 19:04:30.694249",
  "modified_by": "Administrator",
  "module": "Phamos",
  "name": "Implementation",
- "naming_rule": "By fieldname",
+ "naming_rule": "Set by user",
  "owner": "Administrator",
  "permissions": [
   {
@@ -92,7 +120,9 @@
    "write": 1
   }
  ],
+ "search_fields": "account_manager",
  "sort_field": "modified",
  "sort_order": "DESC",
- "states": []
+ "states": [],
+ "track_changes": 1
 }

--- a/phamos/phamos/doctype/implementation/implementation.py
+++ b/phamos/phamos/doctype/implementation/implementation.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2025, phamos.eu and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class Implementation(Document):
+	pass

--- a/phamos/phamos/doctype/implementation/test_implementation.py
+++ b/phamos/phamos/doctype/implementation/test_implementation.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2025, phamos.eu and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestImplementation(FrappeTestCase):
+	pass


### PR DESCRIPTION
**Gitlab Issue:** 

- https://git.phamos.eu/phamos/phamos/-/work_items/33

**Summary of Requirement**

The requirement is to redo the `Implementation` doctype as is on the Production environment. Both replicate the form and the list view.

The Implementation change is showed on the GIF below;

- Added all the fields
- Filtered the Account Manager field to allow only Users with `Account Manager` role
- Added relevant fields to the listview

![Video_250109122159 (2)](https://github.com/user-attachments/assets/bdea187e-f779-484a-bfb2-4bfdad074d79)

**The Implementation on the `Production` Environment is reflected in screenshots below**
<img width="950" alt="impl_prod_l" src="https://github.com/user-attachments/assets/8c9ce80b-4be5-4f8c-a8f1-483f7f5dd9a2" />
<img width="487" alt="implform_prod_l" src="https://github.com/user-attachments/assets/8bb5e22a-e14e-475c-a58a-f4d3b6dc0c8b" />


**The Implementation I did is as in screenshots below**
<img width="723" alt="local_form" src="https://github.com/user-attachments/assets/3e8cb629-32ae-44be-89ec-9ef78f08c333" />
<img width="950" alt="local_listview" src="https://github.com/user-attachments/assets/bac8c55b-b811-45db-bedb-5cb8d44f1cca" />

