### PR TITLE
Updated missing fields in Project Action Panel

### DIFF
--- a/phamos/phamos/page/project_action_panel/project_action_panel.js
+++ b/phamos/phamos/page/project_action_panel/project_action_panel.js
@@ -176,7 +176,8 @@ frappe.pages["project-action-panel"].on_page_load = function (wrapper) {
 
 
   window.stopProject = function (timesheet_record, percent_billable,project,task,task_in_timesheet_record) {
-    let activity_type = "";
+    let from_time = '';
+    let expected_time = ''
     let timesheet_record_info = " Info from timesheet record";
     frappe.db.get_value(
       "Timesheet Record",


### PR DESCRIPTION
https://git.phamos.eu/phamos/phamos/-/work_items/143

Updated from_time and expected_time fields in Project Action Panel.

Removed field activity_type. because it declared but never used.