### PR TITLE
Display billable hours in project action panel #122

### DIFF
--- a/phamos/phamos/page/project_action_panel/project_action_panel.js
+++ b/phamos/phamos/page/project_action_panel/project_action_panel.js
@@ -592,9 +592,8 @@ frappe.pages["project-action-panel"].on_page_load = function (wrapper) {
     });
   };
 
-
   // Function to render number cards
-  function render_cards(wrapper, card_names) {
+  function render_cards(wrapper, card_names, tab='') {
     return frappe.call({
       method: "phamos.phamos.page.project_action_panel.project_action_panel.get_permitted_cards",
       args: { 
@@ -605,18 +604,19 @@ frappe.pages["project-action-panel"].on_page_load = function (wrapper) {
         if (!cards || !cards.length) {
           return;
         }
-
-      // Filter the cards based on card_names
+    
+        // Filter the cards based on card_names
         var filtered_cards = cards.filter(function(card) {
           return card_names.includes(card.card);
         });
-
+    
         var number_cards = filtered_cards.map(function (card) {
           return {
             name: card.card,
           };
         });
-
+    
+        // Create a widget group for number cards
         var number_card_group = new frappe.widget.WidgetGroup({
           container: wrapper, 
           type: "number_card",
@@ -630,18 +630,90 @@ frappe.pages["project-action-panel"].on_page_load = function (wrapper) {
           },
           widgets: number_cards,
         });
-
+    
+        // Style the number card widgets
         $(wrapper).find(".widget.number-widget-box").css({
-         width: "250px", 
+          width: "250px", 
         });
-
+    
         $(wrapper).find(".widget-group-body.grid-col-3").css({
           display: "flex", 
           "flex-wrap": "nowrap", 
         });
+    
+        // Custom widget logic to dynamically inject data
+        let widgetGroupBody = $(wrapper).find(".widget-group-body");
+        widgetGroupBody.empty(); // Clear existing widgets before appending new ones
+    
+        // Fetch data for the cards using API calls
+        let fetch_projects = "phamos.phamos.page.project_action_panel.project_action_panel.get_project_count"
+        if(tab == "All Projects"){
+          fetch_projects = "phamos.phamos.page.project_action_panel.project_action_panel.get_project_count_all"
+        }
+        Promise.all([
+          frappe.call({ method:  fetch_projects}),
+          frappe.call({ method: "phamos.phamos.page.project_action_panel.project_action_panel.total_hours_worked_today" }),
+          frappe.call({ method: "phamos.phamos.page.project_action_panel.project_action_panel.total_hours_worked_in_this_week" }),
+          frappe.call({ method: "phamos.phamos.page.project_action_panel.project_action_panel.total_hours_worked_in_this_month" })
+        ])
+        .then(function (results) {
+          // Assuming the results are in the same order as the requests
+          const [projectCountResult, totalTodayResult, totalWeekResult, totalMonthResult] = results;
+          
+          // Handle the result for each card type
+          let projectCount = projectCountResult.message;
+          let monthly_working = totalMonthResult.message;
+          let weekly_working = totalWeekResult.message;
+          let today_working = totalTodayResult.message;
+
+          
+          // Add custom widgets to the page based on the fetched data
+          let customCards = [
+            { name: "Total Projects", labels: ["Projects"], values: [projectCount.value || 0] },
+            { name: "Total Hours Worked Today", labels: ["Working", "Billable"], values: [today_working.value || 0, today_working.billable || 0] },
+            { name: "Total Hours Worked This Week", labels: ["Working", "Billable"], values: [weekly_working.value || 0, weekly_working.billable || 0]},
+            { name: "Total Hours Worked This Month", labels: ["Working", "Billable"], values: [monthly_working.value || 0, monthly_working.billable || 0]}
+          ];
+  
+          customCards.forEach(card => {
+            let widgetTitle = card.name;
+            let labels = card.labels;
+            let values = card.values;
+  
+            // Create the custom HTML for each card/widget
+            let customWidgetHTML = `
+              <div class="widget number-widget-box" style="width: 250px; padding: 12px; border-radius: 8px; border: 1px solid #ddd; background: white;">
+                <div class="widget-head" style="display: flex; justify-content: space-between; align-items: center; font-size: 12px; font-weight: 600; color: #666;">
+                  <span>${widgetTitle}</span>
+                </div>
+                <div class="widget-body">
+                  <div class="widget-content" style="padding-top:0px !important">
+                    <div style="display: flex; justify-content: space-between; font-size: 12px; font-weight: 600; color: #444; margin-top: 8px;">
+                      <span>${labels[0]}</span>
+                      ${labels[1] != undefined ? `<span>${labels[1]}</span>` : ''}
+                    </div>
+                    <div style="display: flex; justify-content: space-between; font-size: 18px; font-weight: bold; margin-top: 3px;">
+                      <span class="text-dark">${values[0]}</span>
+                      ${values[1] != undefined ? `<span class="text-dark">${values[1]}</span>` : ''}
+                    </div>
+                  </div>
+                </div>
+              </div>
+            `;
+  
+            // Append the custom widget HTML to the widget group body
+            widgetGroupBody.append(customWidgetHTML);
+          });
+        })
+        .catch(function (error) {
+          console.error("Error fetching data:", error);
+        });
       },
     });
   }
+  
+  
+  
 
   
   // Function to render DataTable with tabs
@@ -800,7 +872,7 @@ function show_tab(tab, projectData) {
       card_names = ["Total Projects", "Total Hrs Worked Today", "Total Hrs Worked This Week", "Total Hrs Worked This Month"];
   
       // Render the cards immediately to improve perceived speed
-      render_cards(cardWrapper, card_names);
+      render_cards(cardWrapper, card_names, tab);
 
       // Make an API call to fetch all projects data asynchronously
         frappe.call({

--- a/phamos/phamos/page/project_action_panel/project_action_panel.py
+++ b/phamos/phamos/page/project_action_panel/project_action_panel.py
@@ -216,25 +216,35 @@ def total_hours_worked_today():
     employee_name = frappe.db.get_value("Employee", {"user_id": frappe.session.user}, "name")
     today_date = datetime.today().date()  # Get today's date
     count_time = frappe.db.sql("""
-        SELECT sum(ts.actual_time) AS actual_time
+        SELECT sum(ts.actual_time) AS actual_time,
+        SUM(ts.actual_time * ts.percent_billable / 100) AS total_billable_time
         FROM `tabTimesheet Record` ts
         WHERE ts.employee = %(employee)s AND DATE(ts.from_time) = %(today_date)s
     """, {"employee": employee_name, "today_date": today_date}, as_dict=True)
     
+
     if count_time and count_time[0].actual_time:
         actual_time = format_duration(count_time[0].actual_time)
         actual_time_str = str(actual_time)[:9]
         #frappe.msgprint(f"Total hours worked today: {actual_time_str}")
         
+        # Format billable time
+        total_billable_time = count_time[0].total_billable_time
+        if total_billable_time:
+            total_billable_time = format_duration(total_billable_time)
+            total_billable_time_str = str(total_billable_time)[:10]
+
         return {
             "value": actual_time_str,
-            "fieldtype": "Float"
+            "fieldtype": "Float",
+            "billable": total_billable_time_str or 0
         }
     else:
         actual_time_str = 0
         return {
             "value": actual_time_str,
-            "fieldtype": "Float"
+            "fieldtype": "Float",
+            "billable": 0
         }
 
 
@@ -246,7 +256,8 @@ def total_hours_worked_in_this_week():
     end_of_week = start_of_week + timedelta(days=6)  # Calculate the end of the current week
 
     count_time = frappe.db.sql("""
-        SELECT SUM(ts.actual_time) AS total_actual_time
+        SELECT SUM(ts.actual_time) AS total_actual_time,
+        SUM(ts.actual_time * ts.percent_billable / 100) AS total_billable_time
         FROM `tabTimesheet Record` ts
         WHERE ts.employee = %(employee)s 
         AND ts.from_time BETWEEN %(start_of_week)s AND %(end_of_week)s
@@ -255,17 +266,26 @@ def total_hours_worked_in_this_week():
     if count_time and count_time[0].total_actual_time:
         total_actual_time = format_duration(count_time[0].total_actual_time)
         total_actual_time_str = str(total_actual_time)[:10]
-        #frappe.msgprint(f"Total hours worked this week: {total_actual_time_str}")
+
+        # Format billable time
+        total_billable_time = count_time[0].total_billable_time
+        if total_billable_time:
+            total_billable_time = format_duration(total_billable_time)
+            total_billable_time_str = str(total_billable_time)[:10]
+
+        # frappe.msgprint(f"Total hours worked this week: {total_actual_time_str}")
         
         return {
             "value": total_actual_time_str,
-            "fieldtype": "Float"
+            "fieldtype": "Float",
+            "billable": total_billable_time_str or 0
         }
     else:
         total_actual_time_str = 0
         return {
             "value": total_actual_time_str,
-            "fieldtype": "Float"
+            "fieldtype": "Float",
+            "billable": 0
         }
 
 
@@ -283,7 +303,8 @@ def total_hours_worked_in_this_month():
     end_of_month = next_month - timedelta(days=1)  # Calculate the end of the current month
 
     count_time = frappe.db.sql("""
-        SELECT SUM(ts.actual_time) AS total_actual_time
+        SELECT SUM(ts.actual_time) AS total_actual_time,
+        SUM(ts.actual_time * ts.percent_billable / 100) AS total_billable_time
         FROM `tabTimesheet Record` ts
         WHERE ts.employee = %(employee)s 
         AND ts.from_time BETWEEN %(start_of_month)s AND %(end_of_month)s
@@ -292,29 +313,38 @@ def total_hours_worked_in_this_month():
     if count_time and count_time[0].total_actual_time:
         total_actual_time = format_duration(count_time[0].total_actual_time)
         total_actual_time_str = str(total_actual_time)[:10]
-        #frappe.msgprint(f"Total hours worked this month: {total_actual_time_str}")
+
+        # Format billable time
+        total_billable_time = count_time[0].total_billable_time
+        if total_billable_time:
+            total_billable_time = format_duration(total_billable_time)
+            total_billable_time_str = str(total_billable_time)[:10]
+
+        # frappe.msgprint(f"Total hours worked this month: {total_actual_time_str}")
         
         return {
             "value": total_actual_time_str,
-            "fieldtype": "Float"
+            "fieldtype": "Float",
+            "billable": total_billable_time_str or 0
         }
     else:
         total_actual_time_str = 0
         return {
             "value": total_actual_time_str,
-            "fieldtype": "Float"
+            "fieldtype": "Float",
+            "billable": 0
         }
 
 
 def format_duration(duration_in_seconds):
-	minutes, seconds = divmod(duration_in_seconds, 60)
-	hours, minutes = divmod(minutes, 60)
-	if hours > 0:
-		return f"{hours} Hrs {minutes} Mins"
-	elif minutes > 0:
-		return f"{minutes} Mins"
-	else:
-		return f"{seconds} Secs"
+    minutes, seconds = divmod(duration_in_seconds, 60)
+    hours, minutes = divmod(minutes, 60)
+    if hours > 0:
+        return f"{int(hours)} Hrs"
+    elif minutes > 0:
+        return f"{int(minutes)} Mins"
+    else:
+        return f"{int(seconds)} Secs"
 
 
 @frappe.whitelist()

--- a/phamos/phamos/page/project_action_panel/project_action_panel.py
+++ b/phamos/phamos/page/project_action_panel/project_action_panel.py
@@ -7,6 +7,7 @@ from datetime import datetime
 from datetime import datetime, timedelta
 from frappe.query_builder import Field,Case, Order
 from frappe.query_builder.functions import Concat,Max
+from frappe.query_builder import DocType, functions as fn
 
 @frappe.whitelist()
 def create_timesheet_record(project_name,  customer, from_time, expected_time, goal,task=None):
@@ -196,7 +197,6 @@ def get_project_count():
         #"count_projects": count_projects[0].get('total_projects') if count_projects else 0  # assuming you want to return the count of projects meeting certain conditions
     }
 
-
 @frappe.whitelist()
 def get_project_count_all():
     count_projects = frappe.db.sql("""
@@ -210,43 +210,47 @@ def get_project_count_all():
         #"count_projects": count_projects[0].get('total_projects') if count_projects else 0  # assuming you want to return the count of projects meeting certain conditions
     }
 
-
 @frappe.whitelist()
 def total_hours_worked_today():
     employee_name = frappe.db.get_value("Employee", {"user_id": frappe.session.user}, "name")
     today_date = datetime.today().date()  # Get today's date
-    count_time = frappe.db.sql("""
-        SELECT sum(ts.actual_time) AS actual_time,
-        SUM(ts.actual_time * ts.percent_billable / 100) AS total_billable_time
-        FROM `tabTimesheet Record` ts
-        WHERE ts.employee = %(employee)s AND DATE(ts.from_time) = %(today_date)s
-    """, {"employee": employee_name, "today_date": today_date}, as_dict=True)
-    
+    TimesheetRecord = DocType("Timesheet Record")
+    count_time = (
+        frappe.qb.from_(TimesheetRecord)
+        .select(
+            fn.Sum(TimesheetRecord.actual_time).as_("actual_time"),
+            fn.Sum(TimesheetRecord.actual_time * TimesheetRecord.percent_billable / 100).as_("total_billable_time")
+        )
+        .where(
+            (TimesheetRecord.employee == employee_name)
+            & (fn.Date(TimesheetRecord.from_time) == today_date)
+        )
+        .run(as_dict=True)
+    )
 
     if count_time and count_time[0].actual_time:
+        # Format actual time
         actual_time = format_duration(count_time[0].actual_time)
         actual_time_str = str(actual_time)[:9]
-        #frappe.msgprint(f"Total hours worked today: {actual_time_str}")
-        
-        # Format billable time
+
+        # Format billable time if it exists
         total_billable_time = count_time[0].total_billable_time
         if total_billable_time:
             total_billable_time = format_duration(total_billable_time)
             total_billable_time_str = str(total_billable_time)[:10]
-
+        
         return {
             "value": actual_time_str,
             "fieldtype": "Float",
             "billable": total_billable_time_str or 0
         }
     else:
-        actual_time_str = 0
+        # If no time was worked, return zero
         return {
-            "value": actual_time_str,
+            "value": 0,
             "fieldtype": "Float",
             "billable": 0
         }
-
 
 @frappe.whitelist()
 def total_hours_worked_in_this_week():
@@ -255,14 +259,20 @@ def total_hours_worked_in_this_week():
     start_of_week = today_date - timedelta(days=today_date.weekday())  # Calculate the start of the current week
     end_of_week = start_of_week + timedelta(days=6)  # Calculate the end of the current week
 
-    count_time = frappe.db.sql("""
-        SELECT SUM(ts.actual_time) AS total_actual_time,
-        SUM(ts.actual_time * ts.percent_billable / 100) AS total_billable_time
-        FROM `tabTimesheet Record` ts
-        WHERE ts.employee = %(employee)s 
-        AND ts.from_time BETWEEN %(start_of_week)s AND %(end_of_week)s
-    """, {"employee": employee_name, "start_of_week": start_of_week, "end_of_week": end_of_week}, as_dict=True)
-    
+    TimesheetRecord = DocType("Timesheet Record")
+    count_time = (
+        frappe.qb.from_(TimesheetRecord)
+        .select(
+            fn.Sum(TimesheetRecord.actual_time).as_("total_actual_time"),
+            fn.Sum(TimesheetRecord.actual_time * TimesheetRecord.percent_billable / 100).as_("total_billable_time")
+        )
+        .where(
+            (TimesheetRecord.employee == employee_name)
+            & (TimesheetRecord.from_time.between(start_of_week, end_of_week))
+        )
+        .run(as_dict=True)
+    )
+
     if count_time and count_time[0].total_actual_time:
         total_actual_time = format_duration(count_time[0].total_actual_time)
         total_actual_time_str = str(total_actual_time)[:10]
@@ -272,8 +282,6 @@ def total_hours_worked_in_this_week():
         if total_billable_time:
             total_billable_time = format_duration(total_billable_time)
             total_billable_time_str = str(total_billable_time)[:10]
-
-        # frappe.msgprint(f"Total hours worked this week: {total_actual_time_str}")
         
         return {
             "value": total_actual_time_str,
@@ -281,13 +289,11 @@ def total_hours_worked_in_this_week():
             "billable": total_billable_time_str or 0
         }
     else:
-        total_actual_time_str = 0
         return {
-            "value": total_actual_time_str,
+            "value": 0,
             "fieldtype": "Float",
             "billable": 0
         }
-
 
 @frappe.whitelist()
 def total_hours_worked_in_this_month():
@@ -302,14 +308,20 @@ def total_hours_worked_in_this_month():
         next_month = start_of_month.replace(month=start_of_month.month + 1)  # Calculate the start of the next month
     end_of_month = next_month - timedelta(days=1)  # Calculate the end of the current month
 
-    count_time = frappe.db.sql("""
-        SELECT SUM(ts.actual_time) AS total_actual_time,
-        SUM(ts.actual_time * ts.percent_billable / 100) AS total_billable_time
-        FROM `tabTimesheet Record` ts
-        WHERE ts.employee = %(employee)s 
-        AND ts.from_time BETWEEN %(start_of_month)s AND %(end_of_month)s
-    """, {"employee": employee_name, "start_of_month": start_of_month, "end_of_month": end_of_month}, as_dict=True)
-     
+    TimesheetRecord = DocType("Timesheet Record")
+    count_time = (
+        frappe.qb.from_(TimesheetRecord)
+        .select(
+            fn.Sum(TimesheetRecord.actual_time).as_("total_actual_time"),
+            fn.Sum(TimesheetRecord.actual_time * TimesheetRecord.percent_billable / 100).as_("total_billable_time")
+        )
+        .where(
+            (TimesheetRecord.employee == employee_name)
+            & (TimesheetRecord.from_time.between(start_of_month, end_of_month))
+        )
+        .run(as_dict=True)
+    )
+
     if count_time and count_time[0].total_actual_time:
         total_actual_time = format_duration(count_time[0].total_actual_time)
         total_actual_time_str = str(total_actual_time)[:10]
@@ -319,8 +331,6 @@ def total_hours_worked_in_this_month():
         if total_billable_time:
             total_billable_time = format_duration(total_billable_time)
             total_billable_time_str = str(total_billable_time)[:10]
-
-        # frappe.msgprint(f"Total hours worked this month: {total_actual_time_str}")
         
         return {
             "value": total_actual_time_str,
@@ -328,13 +338,11 @@ def total_hours_worked_in_this_month():
             "billable": total_billable_time_str or 0
         }
     else:
-        total_actual_time_str = 0
         return {
-            "value": total_actual_time_str,
+            "value": 0,
             "fieldtype": "Float",
             "billable": 0
         }
-
 
 def format_duration(duration_in_seconds):
     minutes, seconds = divmod(duration_in_seconds, 60)


### PR DESCRIPTION
Issue => https://git.phamos.eu/phamos/phamos/-/work_items/122

Parent Issue => https://git.phamos.eu/phamos/phamos/-/issues/79

In this update, I have added a feature to display the total hours worked and the billable hours for every employee in the Project Action Panel. This allows employees to quickly see their total work hours and the portion of those hours that are billable, broken down by Today, This Week, and This Month.

Update format_duration to Return Integer Values and Remove Minutes:

- [ ] Added int() to ensure duration values are returned as integers (to prevent float values).
- [ ] Removed minutes from the output when displaying hours, as it was unnecessary for the card display.
- [ ] The function now returns hours, minutes, or seconds in a simplified format.

**Before**
![image](https://github.com/user-attachments/assets/9b95a2a1-caf7-4efe-93d6-72183e4a96bb)

**After**
![image](https://github.com/user-attachments/assets/6a98ece0-4dd3-4fba-863a-ca62aef6557e)
