### PR TITLE
fixed #142: Sorting order of Your Projects

### DIFF
--- a/phamos/phamos/page/project_action_panel/project_action_panel.py
+++ b/phamos/phamos/page/project_action_panel/project_action_panel.py
@@ -205,7 +205,8 @@ def fetch_projects():
                 & (ToDo.allocated_to == frappe.session.user)
             ).isnotnull()
         )
-        .orderby(Coalesce(last_timesheet_update, frappe.utils.now()), order=Order.desc)
+        .orderby(Coalesce(last_timesheet_update, "1970, 1, 1"), order=Order.desc)
+        
     )
     # Execute query
     projects = query.run(as_dict=True)


### PR DESCRIPTION
**issue:**   https://git.phamos.eu/phamos/phamos/-/work_items/142

**Parent Issue:** https://git.phamos.eu/phamos/phamos/-/issues/79


**Handling Sorting of Projects with No Last Timesheet Update**

- The issue occurs because projects without a last_timesheet_update (i.e., None or NULL values) are appearing at the top instead of the bottom.
- This happens because the system treats missing values as the most recent timestamps, pushing them ahead of properly updated records.
- To fix this, we need to ensure that projects with no updates are treated as the oldest instead of the newest when sorting.