### PR TITLE
fixed issue #159: Total billable hours bug Project Action Panel

### DIFF
--- a/phamos/phamos/page/project_action_panel/project_action_panel.py
+++ b/phamos/phamos/page/project_action_panel/project_action_panel.py
@@ -319,6 +319,7 @@ def total_hours_worked_today():
 
         # Format billable time if it exists
         total_billable_time = count_time[0].total_billable_time
+        total_billable_time_str = 0
         if total_billable_time:
             total_billable_time = format_duration(total_billable_time)
             total_billable_time_str = str(total_billable_time)[:10]
@@ -326,7 +327,7 @@ def total_hours_worked_today():
         return {
             "value": actual_time_str,
             "fieldtype": "Float",
-            "billable": total_billable_time_str or 0
+            "billable": total_billable_time_str
         }
     else:
         # If no time was worked, return zero
@@ -363,6 +364,7 @@ def total_hours_worked_in_this_week():
 
         # Format billable time
         total_billable_time = count_time[0].total_billable_time
+        total_billable_time_str = 0
         if total_billable_time:
             total_billable_time = format_duration(total_billable_time)
             total_billable_time_str = str(total_billable_time)[:10]
@@ -370,7 +372,7 @@ def total_hours_worked_in_this_week():
         return {
             "value": total_actual_time_str,
             "fieldtype": "Float",
-            "billable": total_billable_time_str or 0
+            "billable": total_billable_time_str
         }
     else:
         return {
@@ -412,6 +414,7 @@ def total_hours_worked_in_this_month():
 
         # Format billable time
         total_billable_time = count_time[0].total_billable_time
+        total_billable_time_str = 0
         if total_billable_time:
             total_billable_time = format_duration(total_billable_time)
             total_billable_time_str = str(total_billable_time)[:10]
@@ -419,7 +422,7 @@ def total_hours_worked_in_this_month():
         return {
             "value": total_actual_time_str,
             "fieldtype": "Float",
-            "billable": total_billable_time_str or 0
+            "billable": total_billable_time_str
         }
     else:
         return {


### PR DESCRIPTION
issue: https://git.phamos.eu/phamos/phamos/-/work_items/159

Parent Issue: https://git.phamos.eu/phamos/phamos/-/issues/158

Description:

Declare the variable total_billable_time_str with a default value of "0 billable hours" to prevent the error UnboundLocalError: cannot access local variable 'total_billable_time_str' before it is assigned a value.