### PR TITLE
[#147][Corrected the timesheet record script]

### DIFF
--- a/phamos/phamos/doctype/timesheet_record/timesheet_record.py
+++ b/phamos/phamos/doctype/timesheet_record/timesheet_record.py
@@ -36,7 +36,7 @@ class TimesheetRecord(Document):
 		timesheet = frappe.new_doc("Timesheet")
 		timesheet.update(
 			{
-				"project": self.project,
+				"project": self.parent_project,
 				"customer": self.customer,
 				"note": description,
 				"employee": self.employee


### PR DESCRIPTION
**Parent:** https://git.phamos.eu/phamos/phamos/-/issues/146
**Child:** https://git.phamos.eu/phamos/phamos/-/work_items/147
**Description:**

This PR modifies the timesheet record script to ensure that the project value is stored in the correct standard field when mapping a timesheet record to the timesheet form.
  