### PR TITLE
Hot fix - Timesheet record issue

### DIFF
--- a/phamos/phamos/doctype/timesheet_record/timesheet_record.py
+++ b/phamos/phamos/doctype/timesheet_record/timesheet_record.py
@@ -36,7 +36,7 @@ class TimesheetRecord(Document):
 		timesheet = frappe.new_doc("Timesheet")
 		timesheet.update(
 			{
-				"project": self.parent_project,
+				"parent_project": self.project,
 				"customer": self.customer,
 				"note": description,
 				"employee": self.employee


### PR DESCRIPTION
**Description:**  This PR introduces a hotfix for the Timesheet doctype. The issue was that submitting a Timesheet from the Project Action Panel created a Timesheet Record entry but failed to generate an actual Timesheet document.