### PR TITLE
radar chart for modules level

### DIFF
--- a/phamos/phamos/doctype/implementation/implementation.js
+++ b/phamos/phamos/doctype/implementation/implementation.js
@@ -4,39 +4,50 @@ frappe.ui.form.on("Implementation", {
 	setup:function(frm){
 		if(!frm.is_new()){
 			add_row_to_sales_order(frm)
-			frappe.call({
-				method: "phamos.phamos.doctype.implementation.implementation.get_financial_history",
-				args: {'name':frm.doc.name,'customer':frm.doc.customer},
-				callback: function (r) {
-					if(r.message){
-						frm.set_value('sales_order_total_hrs', r.message['sales_order_qty'])
-						frm.set_value('delivered_total_hrs', r.message['dn_qty'])
-						frm.set_value('total_hrs_timesheet', r.message['timesheet_hrs'])
-						frm.set_value('remaining_hrs',r.message['remaining_hrs'])
-						let label1= ['Sales Order Hrs']
-		                let value1 = [r.message['sales_order_qty']]
+			if (frm.doc.internal_implementation == 0) {
+				frappe.call({
+					method: "phamos.phamos.doctype.implementation.implementation.get_financial_history",
+					args: {'name':frm.doc.name,'customer':frm.doc.customer},
+					callback: function (r) {
+						if(r.message){
+							frm.set_value('sales_order_total_hrs', r.message['sales_order_qty'])
+							frm.set_value('delivered_total_hrs', r.message['dn_qty'])
+							frm.set_value('total_hrs_timesheet', r.message['timesheet_hrs'])
+							frm.set_value('remaining_hrs',r.message['remaining_hrs'])
+							let label1= ['Sales Order Hrs']
+							let value1 = [r.message['sales_order_qty']]
 
-		                
-		                $(frm.fields_dict.total_sales.wrapper).html('<div id="total-sales"><h1>hiiii</h1></div>');
-		                
-		                let chart = new frappe.Chart("#total-sales", {
-		                    type: 'percentage',
-		                    data: {
-		                        labels: label1,
-		                        datasets: [
-				                    {name:"Financial Information",values: value1}]},
-		                    colors: ['#7cd6fd'],
-		                    height: 250,
-		                    width:250
-		                });
-		                
-						frm.save()
-					}
-				},
-			});
+							
+							$(frm.fields_dict.total_sales.wrapper).html('<div id="total-sales"><h1>hiiii</h1></div>');
+							
+							let chart = new frappe.Chart("#total-sales", {
+								type: 'percentage',
+								data: {
+									labels: label1,
+									datasets: [
+										{name:"Financial Information",values: value1}]},
+								colors: ['#7cd6fd'],
+								height: 250,
+								width:250
+							});
+							
+							frm.save()
+						}
+					},
+				});
+			}
 		}
 	},
 	refresh: function(frm) {
+		// radar chart
+		if (!frm.fields_dict.module_chart.$wrapper.find('canvas').length) {
+            frm.fields_dict.module_chart.$wrapper.html('<canvas id="radar-chart" style="height: 500px;width: 500px;"></canvas>');
+        }
+
+        frappe.require("https://cdn.jsdelivr.net/npm/chart.js", function () {
+            render_module_chart(frm);
+        });
+		// radar chart ends
 		if(!frm.is_new()){ 
 			frappe.call({
 				method: "phamos.phamos.doctype.implementation.implementation.get_financial_history",
@@ -133,8 +144,65 @@ frappe.ui.form.on("Implementation", {
         }
     }
 });
+function render_module_chart(frm) {
+    const labels = [];
+    const currentLevels = [];
+    const targetLevels = [];
 
+    (frm.doc.modules || []).forEach(row => {
+        if (row.is_required) {
+            labels.push(row.module);
+            currentLevels.push(row.current_level || 0);
+            targetLevels.push(row.target_level || 0);
+        }
+    });
 
+    const ctx = document.getElementById('radar-chart');
+    if (!ctx) return;
+
+    if (window.moduleRadarChart) {
+        window.moduleRadarChart.destroy();
+    }
+
+    window.moduleRadarChart = new Chart(ctx, {
+        type: 'radar',
+        data: {
+            labels: labels,
+            datasets: [
+                {
+                    label: 'Current Level',
+                    data: currentLevels,
+                    backgroundColor: 'rgba(75, 202, 234, 0.3)',
+                    borderColor: '#00bcd4',
+                    borderWidth: 2
+                },
+                {
+                    label: 'Target Level',
+                    data: targetLevels,
+                    backgroundColor: 'rgba(192, 5, 5, 0.2)',
+                    borderColor: 'red',
+                    borderWidth: 2
+                }
+            ]
+        },
+        options: {
+            responsive: true,
+			maintainAspectRatio: false,
+
+            scales: {
+                r: {
+                    suggestedMin: 0,
+                    suggestedMax: 10,
+                    pointLabels: {
+                        font: {
+                            size: 12
+                        }
+                    }
+                }
+            }
+        }
+    });
+}
 
 function add_row_to_sales_order(frm){
 	frappe.call({

--- a/phamos/phamos/doctype/implementation/implementation.json
+++ b/phamos/phamos/doctype/implementation/implementation.json
@@ -37,6 +37,8 @@
   "resource_planning_tab",
   "resource_planning",
   "modules_tab",
+  "target_level",
+  "module_chart",
   "modules"
  ],
  "fields": [
@@ -222,6 +224,17 @@
    "fieldtype": "Table",
    "label": "Modules",
    "options": "Implementation Item"
+  },
+  {
+   "fieldname": "target_level",
+   "fieldtype": "HTML",
+   "label": "Target Level",
+   "options": "<div><h6>Target Level 0-10 (0= not implementing, 10 = full implementation , 5 = basic implementation )</h6></div>\n\n"
+  },
+  {
+   "fieldname": "module_chart",
+   "fieldtype": "HTML",
+   "label": "Module Chart"
   }
  ],
  "index_web_pages_for_search": 1,
@@ -247,7 +260,7 @@
    "link_fieldname": "custom_implementation"
   }
  ],
- "modified": "2025-04-25 16:16:00.103448",
+ "modified": "2025-05-02 15:39:06.094274",
  "modified_by": "Administrator",
  "module": "Phamos",
  "name": "Implementation",

--- a/phamos/phamos/doctype/implementation/implementation.py
+++ b/phamos/phamos/doctype/implementation/implementation.py
@@ -92,7 +92,9 @@ class Implementation(Document):
 						
 
 @frappe.whitelist()
-def get_financial_history(name, customer):
+def get_financial_history(name, customer = None):
+	if not customer:
+		return {}
 	get_projects = frappe.db.get_all('Project', {'custom_implementation':name}, 'name')
 	
 	get_project_list = [item.name for item in get_projects]


### PR DESCRIPTION
**Radar chart for modules level**

\`## Description

Added a radar chart in the module tab of Implementation Doctype to show the progress of the current-level and the target-level of the modules

**Key changes:**

* \[Added 2 HTML fields in the Implementation doctype ]
* 1 field is for the radar chart and the second field is to show text "Target Level 0-10 (0= not implementing, 10 = full implementation, 5 = basic implementation )"
* Also resolve the issue caused by the get_financial_history() function, for this function customer is taking as an argument but for now we add "internal implementation check" for this customer is not mandatory to I write here that if customer = None than no need to run this function

**Related issue(s)/ticket(s):**

Display modules in implementation (issue #146) Done
[#171](https://git.phamos.eu/phamos/phamos/-/work_items/171) Error resolved

**Testing done:**

Did testing on my local system it is working fine now with and without the customer.
Also graph is working fine and showing data accordingly

**Screenshots & GIFs (if applicable):**
![2025-05-02_16-13](https://github.com/user-attachments/assets/da2b4cce-0912-4831-8519-df254e2a6e89)
[peekODCA62.webm](https://github.com/user-attachments/assets/28a51a7f-0a23-4e62-9cb7-a56dcb29f4eb)

