### PR TITLE
Updating of status options (#172)

### DIFF
--- a/phamos/phamos/doctype/implementation/implementation.js
+++ b/phamos/phamos/doctype/implementation/implementation.js
@@ -39,6 +39,119 @@ frappe.ui.form.on("Implementation", {
 		}
 	},
 	refresh: function(frm) {
+		if (!frm.is_new()) {
+			frm.add_custom_button('Set Implementation Status', () => {
+				frappe.call({
+					method: 'phamos.phamos.doctype.implementation.implementation.are_all_projects_closed',
+					args: {
+						implementation_name: frm.doc.name
+					},
+					callback: function (r) {
+						if (r.message === true) {
+							let d = new frappe.ui.Dialog({
+								title: 'Set Implementation Status',
+								fields: [
+									{
+										label: 'Status',
+										fieldname: 'status',
+										fieldtype: 'Select',
+										options: ['Completed', 'Cancelled'],
+										reqd: 1
+									},
+									{
+										label: 'Reason',
+										fieldname: 'reason',
+										fieldtype: 'Small Text',
+										reqd: 1
+									}
+								],
+								primary_action_label: 'Submit',
+								primary_action(values) {
+									frm.set_value('status', values.status);
+									frm.set_value('status_statement', values.reason);
+									frm.save();
+									d.hide();
+								}
+							});
+							d.show();
+						} else {
+							frappe.throw(__('All projects must be closed before setting implementation status.'));
+						}
+					}
+				});
+			});
+		}
+		
+		if (!frm.doc.resource_planning || frm.doc.resource_planning.length === 0) {
+            return;
+        }
+
+        const categories = [];
+        const billable = [];
+        const nonBillable = [];
+
+        frm.doc.resource_planning.forEach(row => {
+            categories.push(row.month_and_year);
+            billable.push(row.billable_time_spent || 0);
+            nonBillable.push(row.non_billable_time_spent || 0);
+        });
+
+        const wrapper = frm.fields_dict.resource_chart.$wrapper;
+        wrapper.empty();
+        wrapper.append('<div id="resource-planning-highchart" style="height:400px;"></div>');
+
+        // Render Highchart
+        Highcharts.chart('resource-planning-highchart', {
+            chart: {
+                type: 'area'
+            },
+            title: {
+                text: 'Billable vs Non-Billable Time'
+            },
+            xAxis: {
+                categories: categories,
+                tickmarkPlacement: 'on',
+                title: {
+                    enabled: false
+                }
+            },
+            yAxis: {
+                title: {
+                    text: ''
+                },
+                labels: {
+                    formatter: function () {
+                        return this.value;
+                    }
+                }
+            },
+            tooltip: {
+                shared: true,
+                valueSuffix: 'hrs'
+            },
+            plotOptions: {
+                area: {
+                    stacking: 'normal',
+                    lineColor: '#666666',
+                    lineWidth: 1,
+                    marker: {
+                        enabled: false
+                    }
+                }
+            },
+            series: [
+				{
+					name: 'Non-Billable Time',
+					data: nonBillable,
+					color: '#ff9933'
+				},
+				{
+                name: 'Billable Time',
+                data: billable,
+                color: '#3399ff'
+            },]
+        });
+    
 		// radar chart
 		if (!frm.fields_dict.module_chart.$wrapper.find('canvas').length) {
             frm.fields_dict.module_chart.$wrapper.html('<canvas id="radar-chart" style="height: 500px;width: 500px;"></canvas>');

--- a/phamos/phamos/doctype/implementation/implementation.json
+++ b/phamos/phamos/doctype/implementation/implementation.json
@@ -13,8 +13,9 @@
   "department",
   "account_manager",
   "maturity_level",
-  "mood",
   "forecast",
+  "trend",
+  "status_statement",
   "section_break_uiri",
   "sales_order_total_hrs",
   "total_hrs_timesheet",
@@ -35,6 +36,7 @@
   "section_break_izec",
   "status_information",
   "resource_planning_tab",
+  "resource_chart",
   "resource_planning",
   "modules_tab",
   "target_level",
@@ -81,13 +83,7 @@
    "in_preview": 1,
    "in_standard_filter": 1,
    "label": "Maturity Level",
-   "options": "1 - Start der Implementierung, keine Vorerfahrung, noch kein\n2 - Poweruser kann sich orientieren,\n3 - Live-Betrieb, Erste Module sind im Einsatz,\n4 - Erste Module abgeschlossen, Entwicklungsprozesse in der Tiefe verstanden,\n5 - Quasi-abgeschlossen, System ist implementiert, Viele geschulte Anwender, hoher Automatisierungsgrad,"
-  },
-  {
-   "fieldname": "mood",
-   "fieldtype": "Select",
-   "label": "Mood",
-   "options": "1\n2\n3\n4\n5"
+   "options": "1 - Early Implementation, no previous Frappe experience\n2 - Initial development work, Poweruser can navigate system\n3 - Development process understood, first modules customized\n4 - Go Live, first modules in use with real life data\n5 - Ongoing development in parallel to system in daily use with live data\n6 - System in daily use, development work limited to customer support"
   },
   {
    "fieldname": "forecast",
@@ -95,13 +91,8 @@
    "in_list_view": 1,
    "in_preview": 1,
    "in_standard_filter": 1,
-   "label": "Forecast",
+   "label": "Implementation Status",
    "options": "1 \u2600\ufe0f - alles gut. Kunde happy, keine Gefahren (deadlines, Erwartung an Stunden etc) in sicht\n2 \ud83c\udf24\ufe0f - zu viele neue Issues, feedback langsam\n3 \u2601\ufe0f - weekly findet nicht jede Woche statt, Kundenprojektmanager schwer zu erreichen,\n4 \ud83c\udf27\ufe0f - Anforderungen \u00e4ndern sich sehr h\u00e4ufig, Weeklies werden nicht wahrgenommen, kunde antwortet auf Mails nicht\n5 \u26c8\ufe0f - Kunde zahlt Rechnungen nicht, Kunde hat keine Gedult"
-  },
-  {
-   "fieldname": "status",
-   "fieldtype": "Small Text",
-   "label": "Status"
   },
   {
    "fieldname": "section_break_uiri",
@@ -235,6 +226,31 @@
    "fieldname": "module_chart",
    "fieldtype": "HTML",
    "label": "Module Chart"
+  },
+  {
+   "default": "Open",
+   "fieldname": "status",
+   "fieldtype": "Select",
+   "label": "Status",
+   "options": "Open\nCancelled\nCompleted",
+   "read_only": 1
+  },
+  {
+   "fieldname": "status_statement",
+   "fieldtype": "Small Text",
+   "label": "Status Statement"
+  },
+  {
+   "fieldname": "trend",
+   "fieldtype": "Select",
+   "in_standard_filter": 1,
+   "label": "Trend",
+   "options": "Improving\nStable\nDeclining"
+  },
+  {
+   "fieldname": "resource_chart",
+   "fieldtype": "HTML",
+   "label": "Time spent"
   }
  ],
  "index_web_pages_for_search": 1,
@@ -260,7 +276,7 @@
    "link_fieldname": "custom_implementation"
   }
  ],
- "modified": "2025-05-02 15:39:06.094274",
+ "modified": "2025-05-07 10:27:08.246141",
  "modified_by": "Administrator",
  "module": "Phamos",
  "name": "Implementation",

--- a/phamos/phamos/doctype/implementation/implementation.py
+++ b/phamos/phamos/doctype/implementation/implementation.py
@@ -208,6 +208,14 @@ def get_financial_history(name, customer = None):
 		return get_so_hrs
 
 
+@frappe.whitelist()
+def are_all_projects_closed(implementation_name):
+    linked_projects = frappe.get_all('Project', filters={'custom_implementation': implementation_name}, fields=['status'])
+    
+    for proj in linked_projects:
+        if proj.status not in ['Completed', 'Cancelled']:
+            return False
+    return True
 
 
 @frappe.whitelist()


### PR DESCRIPTION
**Updating of status options (#172)**

Fields are renamed and delete mood field also replaced some of the fields in the Implementation doctype.

**Key changes:**

* "mood" field removed
* "Status" Text field renamed to "Status Statement"
* "Status Statement" moved to be located below "Forecast"
* "Forecast" renamed to "Implementation Status" 
* "Trend" field added below "Status" (formally forecast") with three options (Improving,Stable,Declining)
* Maturity Level options updated In English

**Related issue(s)/ticket(s):**

[#174](https://git.phamos.eu/phamos/phamos/-/work_items/174)

**Testing done:**

Testing is done on my Local 

**Screenshots & GIFs (if applicable):**

![image](https://github.com/user-attachments/assets/9b9dda5d-dfbe-4cc4-ad96-55f988883ee6)
