### PR TITLE
Phamos/phamos#148

### DIFF
--- a/phamos/phamos/doctype/implementation/implementation.json
+++ b/phamos/phamos/doctype/implementation/implementation.json
@@ -39,7 +39,9 @@
   "modules_tab",
   "target_level",
   "module_chart",
-  "modules"
+  "modules",
+  "status_history_tab",
+  "status_updates"
  ],
  "fields": [
   {
@@ -235,6 +237,17 @@
    "fieldname": "module_chart",
    "fieldtype": "HTML",
    "label": "Module Chart"
+  },
+  {
+   "fieldname": "status_history_tab",
+   "fieldtype": "Tab Break",
+   "label": "Status History"
+  },
+  {
+   "fieldname": "status_updates",
+   "fieldtype": "Table",
+   "label": "Status Updates",
+   "options": "Status Information"
   }
  ],
  "index_web_pages_for_search": 1,
@@ -260,7 +273,7 @@
    "link_fieldname": "custom_implementation"
   }
  ],
- "modified": "2025-05-02 15:39:06.094274",
+ "modified": "2025-05-08 07:01:56.819372",
  "modified_by": "Administrator",
  "module": "Phamos",
  "name": "Implementation",
@@ -280,7 +293,6 @@
    "write": 1
   }
  ],
- "row_format": "Dynamic",
  "search_fields": "account_manager",
  "sort_field": "modified",
  "sort_order": "DESC",

--- a/phamos/phamos/doctype/implementation/implementation.py
+++ b/phamos/phamos/doctype/implementation/implementation.py
@@ -8,9 +8,12 @@ from frappe.utils import today
 
 
 class Implementation(Document):
+	print('))))))))))))))))))))))')
 	def before_save(self):
 		self.add_delivered_hrs()
 		self.add_resource_planning()
+		self.add_status_history()
+
 
 	def add_delivered_hrs(self):
 		if self.sales_order_status_information:
@@ -89,6 +92,32 @@ class Implementation(Document):
 								'billable_time_spent':row1.get('billable_time'),
 								'ratio_of_billable_to_non_billable_time_spent':ratio
 								})
+	def add_status_history(self):
+		print('********************')
+		date = today()
+		if self.status_updates:
+			for d in self.status_updates:
+				print('11111111111111')
+				if d.date == today():
+					d.maturity_level = self.maturity_level
+					d.mood = self.mood
+					d.forecast = self.forecast
+				else:
+					print('22222222222222')
+					self.append("status_updates", {
+						"date": today,
+						"maturity_level": self.maturity_level,
+						"mood": self.mood,
+						"forecast": self.forecast
+					})
+		else:
+			print('3333333333333333333')
+			self.append("status_updates", {
+				"date": today,
+				"maturity_level": self.maturity_level,
+				"mood": self.mood,
+				"forecast": self.forecast
+			})
 
 
 						

--- a/phamos/phamos/doctype/implementation/implementation.py
+++ b/phamos/phamos/doctype/implementation/implementation.py
@@ -89,6 +89,8 @@ class Implementation(Document):
 								'billable_time_spent':row1.get('billable_time'),
 								'ratio_of_billable_to_non_billable_time_spent':ratio
 								})
+
+
 						
 
 @frappe.whitelist()

--- a/phamos/phamos/doctype/implementation/implementation.py
+++ b/phamos/phamos/doctype/implementation/implementation.py
@@ -92,28 +92,29 @@ class Implementation(Document):
 								'billable_time_spent':row1.get('billable_time'),
 								'ratio_of_billable_to_non_billable_time_spent':ratio
 								})
+	
+
 	def add_status_history(self):
-		print('********************')
 		date = today()
 		if self.status_updates:
 			for d in self.status_updates:
-				print('11111111111111')
 				if d.date == today():
+					d.status = self.status
 					d.maturity_level = self.maturity_level
 					d.mood = self.mood
 					d.forecast = self.forecast
 				else:
-					print('22222222222222')
 					self.append("status_updates", {
-						"date": today,
+						"date": today(),
+						"status":self.status,
 						"maturity_level": self.maturity_level,
 						"mood": self.mood,
 						"forecast": self.forecast
 					})
 		else:
-			print('3333333333333333333')
 			self.append("status_updates", {
-				"date": today,
+				"date": today(),
+				"status":self.status,
 				"maturity_level": self.maturity_level,
 				"mood": self.mood,
 				"forecast": self.forecast

--- a/phamos/phamos/doctype/status_information/status_information.json
+++ b/phamos/phamos/doctype/status_information/status_information.json
@@ -34,7 +34,6 @@
   {
    "fieldname": "status",
    "fieldtype": "Small Text",
-   "in_list_view": 1,
    "label": "Status",
    "max_height": "200px",
    "width": "50%"
@@ -46,6 +45,7 @@
   {
    "fieldname": "maturity_level",
    "fieldtype": "Select",
+   "in_list_view": 1,
    "label": "Maturity Level",
    "options": "\n1 - Start der Implementierung, keine Vorerfahrung, noch kein\n2 - Poweruser kann sich orientieren,\n3 - Live-Betrieb, Erste Module sind im Einsatz,\n4 - Erste Module abgeschlossen, Entwicklungsprozesse in der Tiefe verstanden,\n5 - Quasi-abgeschlossen, System ist implementiert, Viele geschulte Anwender, hoher Automatisierungsgrad,",
    "width": "10%"
@@ -53,6 +53,7 @@
   {
    "fieldname": "forecast",
    "fieldtype": "Select",
+   "in_list_view": 1,
    "label": "Forecast",
    "options": "1 \u2600\ufe0f - alles gut. Kunde happy, keine Gefahren (deadlines, Erwartung an Stunden etc) in sicht\n2 \ud83c\udf24\ufe0f - zu viele neue Issues, feedback langsam\n3 \u2601\ufe0f - weekly findet nicht jede Woche statt, Kundenprojektmanager schwer zu erreichen,\n4 \ud83c\udf27\ufe0f - Anforderungen \u00e4ndern sich sehr h\u00e4ufig, Weeklies werden nicht wahrgenommen, kunde antwortet auf Mails nicht\n5 \u26c8\ufe0f - Kunde zahlt Rechnungen nicht, Kunde hat keine Gedult",
    "width": "10%"
@@ -66,7 +67,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-03-21 17:26:49.560058",
+ "modified": "2025-05-08 07:00:45.246742",
  "modified_by": "Administrator",
  "module": "Phamos",
  "name": "Status Information",


### PR DESCRIPTION
**Parent:**  https://git.phamos.eu/phamos/phamos/-/issues/162
**Child:** https://git.phamos.eu/phamos/phamos/-/work_items/148
**Description:**

**Purpose**
This PR introduces the add_status_history method in the Implementation doctype to automatically log daily status updates. This supports structured tracking of project progression over time and preserves historical context for later analysis.

**Implementation Details**

The add_status_history method is triggered on the before_save hook.

On each save:

1. It checks whether a status_updates entry already exists for today’s date.
2. If an entry for today exists:
It updates that record with the current values of status, maturity_level, mood, and forecast.

3. If no entry exists for today:
A new record is appended to the status_updates child table with today’s data.

**Benefits**

- Ensures only one status record per day.
- Simplifies historical analysis and auditing of status trends.
- Provides consistency in how progress and forecasts are recorded.