### PR TITLE
Prediction Added in Resource Planning Chart

### DIFF
--- a/phamos/phamos/doctype/implementation/implementation.js
+++ b/phamos/phamos/doctype/implementation/implementation.js
@@ -39,6 +39,7 @@ frappe.ui.form.on("Implementation", {
 		}
 	},
 	refresh: function(frm) {
+		
 		if (!frm.is_new()) {
 			frm.add_custom_button('Set Implementation Status', () => {
 				frappe.call({
@@ -82,75 +83,147 @@ frappe.ui.form.on("Implementation", {
 			});
 		}
 		
-		if (!frm.doc.resource_planning || frm.doc.resource_planning.length === 0) {
-            return;
-        }
+		//////////////////////////////////////////////Resource Planning graph////////////////////////////////////////
 
-        const categories = [];
-        const billable = [];
-        const nonBillable = [];
+        const planningData = frm.doc.resource_planning || [];
+        const predictionData = frm.doc.resource_planning_prediction || [];
 
-        frm.doc.resource_planning.forEach(row => {
-            categories.push(row.month_and_year);
-            billable.push(row.billable_time_spent || 0);
-            nonBillable.push(row.non_billable_time_spent || 0);
+        const categorySet = new Set();
+        planningData.forEach(row => categorySet.add(row.month_and_year));
+        predictionData.forEach(row => categorySet.add(row.month_and_year));
+
+        const categories = Array.from(categorySet).sort((a, b) => new Date(a) - new Date(b));
+
+        const categoryIndexMap = {};
+        categories.forEach((month, idx) => {
+            categoryIndexMap[month] = idx;
+        });
+
+        const billable = new Array(categories.length).fill(0);
+        const nonBillable = new Array(categories.length).fill(0);
+
+        planningData.forEach(row => {
+            const idx = categoryIndexMap[row.month_and_year];
+            billable[idx] += row.billable_time_spent || 0;
+            nonBillable[idx] += row.non_billable_time_spent || 0;
+        });
+
+        const predictionPoints = predictionData
+            .map(row => ({
+                x: categoryIndexMap[row.month_and_year],
+                y: row.prediction || 0
+            }))
+            .sort((a, b) => a.x - b.x); 
+
+        // Calculate monthly average prediction
+        const monthlyPredictionSum = {};
+        const monthlyPredictionCount = {};
+
+        predictionData.forEach(row => {
+            const month = row.month_and_year;
+            const prediction = row.prediction || 0;
+
+            if (!monthlyPredictionSum[month]) {
+                monthlyPredictionSum[month] = 0;
+                monthlyPredictionCount[month] = 0;
+            }
+
+            monthlyPredictionSum[month] += prediction;
+            monthlyPredictionCount[month] += 1;
+        });
+
+        const averagePredictions = categories.map(month => {
+            const sum = monthlyPredictionSum[month] || 0;
+            const count = monthlyPredictionCount[month] || 0;
+            return count > 0 ? sum / count : null;
         });
 
         const wrapper = frm.fields_dict.resource_chart.$wrapper;
         wrapper.empty();
         wrapper.append('<div id="resource-planning-highchart" style="height:400px;"></div>');
 
-        // Render Highchart
         Highcharts.chart('resource-planning-highchart', {
             chart: {
-                type: 'area'
+                zoomType: 'xy'
             },
             title: {
-                text: 'Billable vs Non-Billable Time'
+                text: 'Billable vs Non-Billable Time with Prediction'
             },
             xAxis: {
                 categories: categories,
-                tickmarkPlacement: 'on',
                 title: {
-                    enabled: false
+                    text: 'Month'
                 }
             },
             yAxis: {
                 title: {
-                    text: ''
-                },
-                labels: {
-                    formatter: function () {
-                        return this.value;
-                    }
+                    text: 'Time (hrs)'
                 }
             },
             tooltip: {
                 shared: true,
-                valueSuffix: 'hrs'
+                valueSuffix: ' hrs'
             },
             plotOptions: {
                 area: {
                     stacking: 'normal',
-                    lineColor: '#666666',
-                    lineWidth: 1,
                     marker: {
                         enabled: false
+                    }
+                },
+                line: {
+                    marker: {
+                        enabled: true,
+                        radius: 4
                     }
                 }
             },
             series: [
-				{
-					name: 'Non-Billable Time',
-					data: nonBillable,
-					color: '#ff9933'
-				},
-				{
-                name: 'Billable Time',
-                data: billable,
-                color: '#3399ff'
-            },]
+                {
+                    name: 'Non-Billable Time',
+                    type: 'area',
+                    data: nonBillable,
+                    color: '#ff9933'
+                },
+                {
+                    name: 'Billable Time',
+                    type: 'area',
+                    data: billable,
+                    color: '#3399ff'
+                },
+                {
+                    name: 'Prediction',
+                    type: 'scatter',
+                    data: predictionPoints,
+                    color: '#28a745',
+                    marker: {
+                        symbol: 'circle',
+                        radius: 5
+                    },
+                    tooltip: {
+                        pointFormat: '<span style="color:{series.color}">\u25CF</span> {series.name}: <b>{point.y} hrs</b><br/>'
+                    }
+                },
+                {
+                    name: 'Average Prediction',
+                    type: 'line',
+                    data: averagePredictions,
+                    color: 'red',
+                    dashStyle: 'ShortDash',
+                    marker: {
+                        enabled: true,
+                        symbol: 'diamond',
+                        radius: 4
+                    },
+                    tooltip: {
+                        pointFormat: '<span style="color:{series.color}">\u25CF</span> {series.name}: <b>{point.y:.2f} hrs</b><br/>'
+                    }
+                }
+            ]
         });
+
+
+		//////////////////////////////////////////////////////////////////////////////////////////////////////
     
 		// radar chart
 		if (!frm.fields_dict.module_chart.$wrapper.find('canvas').length) {

--- a/phamos/phamos/doctype/implementation/implementation.json
+++ b/phamos/phamos/doctype/implementation/implementation.json
@@ -38,6 +38,7 @@
   "resource_planning_tab",
   "resource_chart",
   "resource_planning",
+  "resource_planning_prediction",
   "modules_tab",
   "target_level",
   "module_chart",
@@ -248,6 +249,12 @@
    "options": "Improving\nStable\nDeclining"
   },
   {
+   "fieldname": "resource_planning_prediction",
+   "fieldtype": "Table",
+   "label": "Resource Planning Prediction",
+   "options": "Prediction"
+  },
+  {
    "fieldname": "resource_chart",
    "fieldtype": "HTML",
    "label": "Time spent"
@@ -276,7 +283,7 @@
    "link_fieldname": "custom_implementation"
   }
  ],
- "modified": "2025-05-07 10:27:08.246141",
+ "modified": "2025-05-12 19:53:15.683376",
  "modified_by": "Administrator",
  "module": "Phamos",
  "name": "Implementation",

--- a/phamos/phamos/doctype/prediction/prediction.json
+++ b/phamos/phamos/doctype/prediction/prediction.json
@@ -1,0 +1,40 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2025-05-07 12:08:36.660998",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "month_and_year",
+  "prediction"
+ ],
+ "fields": [
+  {
+   "fieldname": "month_and_year",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Month And Year"
+  },
+  {
+   "fieldname": "prediction",
+   "fieldtype": "Int",
+   "in_list_view": 1,
+   "label": "Prediction"
+  }
+ ],
+ "grid_page_length": 50,
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2025-05-13 17:25:20.670010",
+ "modified_by": "Administrator",
+ "module": "Phamos",
+ "name": "Prediction",
+ "owner": "Administrator",
+ "permissions": [],
+ "row_format": "Dynamic",
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/phamos/phamos/doctype/prediction/prediction.py
+++ b/phamos/phamos/doctype/prediction/prediction.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2025, phamos.eu and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class Prediction(Document):
+	pass


### PR DESCRIPTION
**Add resource estimation for future work (#161)**

\`## Description

Added new child table "resource_planning_prediction" in  Implementation doctype to add month-wise predictions.
Shows a graphical representation of the predictions.

**Motivation**

- Added a new child table instead of the existing resource planning table because predictions may be more than 1 for the same month. 
- Uses Highcharts to create an appealing chart

**Key changes:**

* Added Table field in Implementation doctype.
* Created new Child table "Prediction" (links with resource_planning_prediction).
* Created the same Graph for both child tables "resource_planning_prediction" & "resource_planning"
* Green scatter dots represent predictions against similar months, and the red line shows the average of all the predictions month-wise 

**Related issue(s)/ticket(s):**

Issue: **Add resource estimation for future work (#161)**

Parent Issue: **https://git.phamos.eu/phamos/phamos/-/issues/161**

**Testing done:**

Working fine in my local

**Screenshots & GIFs (if applicable):**

![Peek 2025-05-14 11-17](https://github.com/user-attachments/assets/4d4bd041-a77e-4814-b3eb-e88293fdfd21)


