### PR TITLE
resolved error on migration

### DIFF
--- a/phamos/phamos/doctype/resource_planning/resource_planning.json
+++ b/phamos/phamos/doctype/resource_planning/resource_planning.json
@@ -14,19 +14,19 @@
  "fields": [
   {
    "fieldname": "billable_time_spent",
-   "fieldtype": "Int",
+   "fieldtype": "Float",
    "in_list_view": 1,
    "label": "Billable Time spent"
   },
   {
    "fieldname": "total_time",
-   "fieldtype": "Int",
+   "fieldtype": "Float",
    "in_list_view": 1,
    "label": "Total Time"
   },
   {
    "fieldname": "non_billable_time_spent",
-   "fieldtype": "Int",
+   "fieldtype": "Float",
    "in_list_view": 1,
    "label": "Non Billable Time spent"
   },
@@ -40,7 +40,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-05-05 14:37:01.645159",
+ "modified": "2025-05-20 19:33:27.352659",
  "modified_by": "Administrator",
  "module": "Phamos",
  "name": "Resource planning",


### PR DESCRIPTION


\`## Description
This error is occurring because some of the existing records in the Resource Planning table already have values in the billable_time_spent, non_billable_time_spent, and total_time fields. These values were previously stored as Data type (e.g., strings like '79.4885'), and the system is now trying to convert them to an Integer, which causes the migration to fail.

**Key changes:**

I’ve changed the field type from Int to Float instead. This is more appropriate because the original data contains decimal values, and for reporting (especially for graphs where we sum up billable/non-billable time), it's important to preserve decimal precision.

**Related issue(s)/ticket(s):**

Issue: Add resource estimation for future work (#161)
Parent: https://git.phamos.eu/phamos/phamos/-/issues/161


Testing :
Not tested on my local because I don't have any decimal value, and this error is not coming on my local after migration
 
Reference error Picture:
![image](https://github.com/user-attachments/assets/199b460f-7fe0-4214-ab29-672ab8980711)

