### PR TITLE
Date ranges of Resource chart

### DIFF
--- a/phamos/phamos/doctype/implementation/implementation.js
+++ b/phamos/phamos/doctype/implementation/implementation.js
@@ -39,54 +39,91 @@ frappe.ui.form.on("Implementation", {
 		}
 	},
 	refresh: function(frm) {
-		
-		if (!frm.is_new()) {
-			frm.add_custom_button('Set Implementation Status', () => {
-				frappe.call({
-					method: 'phamos.phamos.doctype.implementation.implementation.are_all_projects_closed',
-					args: {
-						implementation_name: frm.doc.name
-					},
-					callback: function (r) {
-						if (r.message === true) {
-							let d = new frappe.ui.Dialog({
-								title: 'Set Implementation Status',
-								fields: [
-									{
-										label: 'Status',
-										fieldname: 'status',
-										fieldtype: 'Select',
-										options: ['Completed', 'Cancelled'],
-										reqd: 1
-									},
-									{
-										label: 'Reason',
-										fieldname: 'reason',
-										fieldtype: 'Small Text',
-										reqd: 1
-									}
-								],
-								primary_action_label: 'Submit',
-								primary_action(values) {
-									frm.set_value('status', values.status);
-									frm.set_value('status_statement', values.reason);
-									frm.save();
-									d.hide();
-								}
-							});
-							d.show();
-						} else {
-							frappe.throw(__('All projects must be closed before setting implementation status.'));
-						}
-					}
-				});
-			});
-		}
+        let options = [];
+        let today = new Date();
+        let currentMonth = today.getMonth(); // 0-based (0 = Jan)
+        let currentYear = today.getFullYear();
+
+        for (let i = 0; i < 12; i++) {
+            let date = new Date(currentYear, currentMonth + i, 1); // add i months
+            let year = date.getFullYear();
+            let month = String(date.getMonth() + 1).padStart(2, '0'); // 1-based month
+            options.push(`${year}-${month}`);
+        }
+
+        console.log("Setting options for month_and_year:", options);
+
+        if (frm.fields_dict['resource_planning_prediction']) {
+            frm.fields_dict['resource_planning_prediction'].grid.update_docfield_property(
+                'month_and_year',
+                'options',
+                options.join('\n')
+            );
+        } else {
+            console.warn("Child table field not available yet.");
+        }
+    
+        frm.add_custom_button('Set Implementation Status', () => {
+            frappe.call({
+                method: 'phamos.phamos.doctype.implementation.implementation.are_all_projects_closed',
+                args: {
+                    implementation_name: frm.doc.name
+                },
+                callback: function (r) {
+                    if (r.message === true) {
+                        let d = new frappe.ui.Dialog({
+                            title: 'Set Implementation Status',
+                            fields: [
+                                {
+                                    label: 'Status',
+                                    fieldname: 'status',
+                                    fieldtype: 'Select',
+                                    options: ['Completed', 'Cancelled'],
+                                    reqd: 1
+                                },
+                                {
+                                    label: 'Reason',
+                                    fieldname: 'reason',
+                                    fieldtype: 'Small Text',
+                                    reqd: 1
+                                }
+                            ],
+                            primary_action_label: 'Submit',
+                            primary_action(values) {
+                                frm.set_value('status', values.status);
+                                frm.set_value('status_statement', values.reason);
+                                frm.save();
+                                d.hide();
+                            }
+                        });
+                        d.show();
+                    } else {
+                        frappe.throw(__('All projects must be closed before setting implementation status.'));
+                    }
+                }
+            });
+        });
+		// }
 		
 		//////////////////////////////////////////////Resource Planning graph////////////////////////////////////////
+        const fromMonth = frm.doc.from_date ? frm.doc.from_date.slice(0, 7) : null;
+        const toMonth = frm.doc.to_date ? frm.doc.to_date.slice(0, 7) : null;
 
-        const planningData = frm.doc.resource_planning || [];
-        const predictionData = frm.doc.resource_planning_prediction || [];
+        function isWithinRange(monthYear, fromMonth, toMonth) {
+            return (!fromMonth || monthYear >= fromMonth) &&
+                (!toMonth || monthYear <= toMonth);
+        }
+
+
+
+        const planningData = (frm.doc.resource_planning || []).filter(row =>
+            row.month_and_year && isWithinRange(row.month_and_year, fromMonth, toMonth)
+        );
+
+        const predictionData = (frm.doc.resource_planning_prediction || []).filter(row =>
+            row.month_and_year && isWithinRange(row.month_and_year, fromMonth, toMonth)
+        );
+
 
         const categorySet = new Set();
         planningData.forEach(row => categorySet.add(row.month_and_year));
@@ -328,6 +365,9 @@ frappe.ui.form.on("Implementation", {
                 }
             });
         }
+        
+
+    
     }
 });
 function render_module_chart(frm) {
@@ -438,4 +478,9 @@ frappe.ui.form.on("Sales Order Status Information", {
 		}
 	}
 });
+
+
+
+
+
 

--- a/phamos/phamos/doctype/implementation/implementation.json
+++ b/phamos/phamos/doctype/implementation/implementation.json
@@ -36,6 +36,10 @@
   "section_break_izec",
   "status_information",
   "resource_planning_tab",
+  "from_date",
+  "column_break_wufw",
+  "to_date",
+  "section_break_5rmv",
   "resource_chart",
   "resource_planning",
   "resource_planning_prediction",
@@ -258,6 +262,26 @@
    "fieldname": "resource_chart",
    "fieldtype": "HTML",
    "label": "Time spent"
+  },
+  {
+   "fieldname": "from_date",
+   "fieldtype": "Select",
+   "label": "From Date",
+   "options": "2025-01\n2025-02\n2025-03\n2025-04\n2025-05\n2025-06"
+  },
+  {
+   "fieldname": "column_break_wufw",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "to_date",
+   "fieldtype": "Select",
+   "label": "To Date",
+   "options": "2025-06\n2025-07\n2025-08\n2025-09\n2025-10\n2025-11\n2025-12"
+  },
+  {
+   "fieldname": "section_break_5rmv",
+   "fieldtype": "Section Break"
   }
  ],
  "index_web_pages_for_search": 1,
@@ -283,7 +307,7 @@
    "link_fieldname": "custom_implementation"
   }
  ],
- "modified": "2025-05-12 19:53:15.683376",
+ "modified": "2025-05-29 15:58:52.889513",
  "modified_by": "Administrator",
  "module": "Phamos",
  "name": "Implementation",

--- a/phamos/phamos/doctype/implementation/implementation.py
+++ b/phamos/phamos/doctype/implementation/implementation.py
@@ -8,7 +8,12 @@ from frappe.utils import today
 
 
 class Implementation(Document):
+		
 	def before_save(self):
+		if self.resource_planning_prediction:
+			self.resource_planning_prediction.sort(
+				key=lambda x: x.month_and_year or ""
+			)
 		self.add_delivered_hrs()
 		self.add_resource_planning()
 

--- a/phamos/phamos/doctype/prediction/prediction.json
+++ b/phamos/phamos/doctype/prediction/prediction.json
@@ -7,12 +7,13 @@
  "engine": "InnoDB",
  "field_order": [
   "month_and_year",
-  "prediction"
+  "prediction",
+  "date"
  ],
  "fields": [
   {
    "fieldname": "month_and_year",
-   "fieldtype": "Data",
+   "fieldtype": "Select",
    "in_list_view": 1,
    "label": "Month And Year"
   },
@@ -21,13 +22,21 @@
    "fieldtype": "Int",
    "in_list_view": 1,
    "label": "Prediction"
+  },
+  {
+   "default": "Today",
+   "fieldname": "date",
+   "fieldtype": "Date",
+   "in_list_view": 1,
+   "label": "Date",
+   "read_only": 1
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-05-13 17:25:20.670010",
+ "modified": "2025-06-02 11:53:13.702129",
  "modified_by": "Administrator",
  "module": "Phamos",
  "name": "Prediction",


### PR DESCRIPTION

\`## Description

New fields added to apply filter on graph data in the Implementation Doctype, added new fields in the child table, also in prediction, month_and_year is added from the selectable to avoid typo error (i-e 2025-13)

**Key changes:**

- Selection option for the prediction is from the current month and year to the next year(Total 12 months in the selection).
- Added filters for the graph date range as shown in the GIF.
- Prediction table data will be sorted by date upon saving.


**Related issue(s)/ticket(s):**

**Issue:** Setting of Date ranges of Resource chart (#161)
**Parent issue:** https://git.phamos.eu/phamos/phamos/-/issues/161


**Testing done:**

Testing Done on Local, also with Gunther

**Screenshots & GIFs (if applicable):**
![Peek 2025-06-02 15-58](https://github.com/user-attachments/assets/71703657-0733-4e1a-9d32-ea58d08ebc84)
![Peek 2025-06-02 16-02](https://github.com/user-attachments/assets/32109f8b-89b3-48db-b6cf-7a5e9d690e58)
![Peek 2025-06-02 17-11](https://github.com/user-attachments/assets/a8018c04-547c-4b16-8bc8-a6f92d845bcf)
