### PR TITLE
Graph in timesheet portal

### DIFF
--- a/phamos/api.py
+++ b/phamos/api.py
@@ -118,3 +118,28 @@ def get_timesheet_totals(from_date=None, to_date=None, project=None):
         "total_hours": total_hours,
         "billable_hours": billable_hours
     }
+
+
+@frappe.whitelist()
+def get_graph_data(from_date=None, to_date=None, project=None):
+    filters = ""
+    if from_date:
+        filters += f" AND start_date >= '{from_date}'"
+    if to_date:
+        filters += f" AND end_date <= '{to_date}'"
+    if project:
+        filters += f" AND project = '{project}'"
+
+    data = frappe.db.sql(f"""
+        SELECT name, start_date, total_hours, total_billable_hours
+        FROM `tabTimesheet`
+        WHERE docstatus < 2 {filters}
+        ORDER BY start_date
+    """, as_dict=True)
+
+    return {"timesheets": data}
+
+
+
+
+

--- a/phamos/www/timesheet/index.html
+++ b/phamos/www/timesheet/index.html
@@ -3,14 +3,22 @@
 {% block style %}
   <link rel="stylesheet" href="/assets/phamos/css/timesheet.css" />
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
+  <script src="https://code.highcharts.com/highcharts.js"></script>
 
 {% endblock %}
 
 {% block page_content %}
 <!-- Subtract ERPNext navbar height -->
-<div class="d-flex flex-column px-3 py-3" style="height: calc(100vh - 56px);">
+<div class="d-flex flex-column px-3 py-3" style="height: calc(130vh - 56px);">
 
   {% include "phamos/www/timesheet/summary_cards.html" %}
+  <!-- Timesheet graph -->
+<div class="card my-3 p-3">
+  <h5>Billable vs Non-Billable vs Total Hours</h5>
+  <div id="timesheet-graph-container" style="height: 400px;"></div>
+</div>
+<!-- Timesheet graph ends -->
+
   <!-- Header Bar -->
   <div class="mb-3">
     <div class="d-flex justify-content-between align-items-center mb-2">

--- a/phamos/www/timesheet/index.js
+++ b/phamos/www/timesheet/index.js
@@ -72,6 +72,7 @@ frappe.ready(() => {
     $('#to_date').val('');
     $('#project_filter').val('');
     reset_and_load();
+    load_graph_data(); /// load graph data//
   });
 
   $(document).on('click', function (event) {
@@ -100,6 +101,7 @@ function reset_and_load() {
   update_summary_cards();
 
   load_timesheets();
+  load_graph_data(); /////////added to load graph
 }
 
 
@@ -347,3 +349,116 @@ function update_summary_cards() {
     }
   });
 }
+//////////////////////////process your timesheets data////////////////////
+function processDataForGraph(timesheets) {
+  const weekData = {};
+
+  timesheets.forEach(row => {
+    const date = new Date(row.start_date);
+    const day = date.getDay(); // 0 (Sun) to 6 (Sat)
+    const diff = date.getDate() - day + (day === 0 ? -6 : 1); // Adjust to Monday
+    const monday = new Date(date.setDate(diff));
+    const weekStart = monday.toISOString().split('T')[0]; // format YYYY-MM-DD
+
+    if (!weekData[weekStart]) {
+      weekData[weekStart] = { total: 0, billable: 0 };
+    }
+
+    weekData[weekStart].total += parseFloat(row.total_hours || 0);
+    weekData[weekStart].billable += parseFloat(row.total_billable_hours || 0);
+  });
+
+  const dataForChart = Object.entries(weekData).map(([week, values]) => ({
+    week,
+    total: values.total,
+    billable: values.billable,
+    non_billable: values.total - values.billable,
+  }));
+
+  dataForChart.sort((a, b) => a.week.localeCompare(b.week));
+
+  renderTimesheetChart(dataForChart);
+}
+
+
+/////////////////////graph//////////////////////
+function renderTimesheetChart(data) {
+  const categories = data.map(row => row.week);
+  const billable = data.map(row => row.billable);
+  const nonBillable = data.map(row => row.non_billable);
+  const total = data.map(row => row.total);
+
+  Highcharts.chart('timesheet-graph-container', {
+    chart: { type: 'area' },
+    title: { text: 'Billable vs Non-Billable vs Total Hours' },
+    xAxis: {
+      categories,
+      title: { text: 'week' }
+    },
+    yAxis: {
+      min: 0,
+      title: { text: 'Hours' }
+    },
+    tooltip: {
+      shared: true,
+      formatter: function () {
+        let s = `<b></b><br/>`;
+        this.points.forEach(point => {
+          s += `<span style="color:${point.color}">\u25CF</span> ${point.series.name}: <b>${point.y.toFixed(2)} hrs</b><br/>`;
+        });
+        return s;
+      }
+    },
+    plotOptions: {
+      area: { stacking: 'normal', marker: { enabled: false } }
+    },
+    series: [
+      { name: 'Non-Billable', data: nonBillable, color: '#ff9933' },
+      { name: 'Billable', data: billable, color: '#3399ff' },
+      { name: 'Total', type: 'spline', data: total, color: '#2ECC71', marker: { enabled: true } }
+    ]
+  });
+}
+/////////////////////////function to fetch all timesheets and trigger the graph/////////////////////
+function loadAndRenderGraph() {
+  const from_date = $('#from_date').val();
+  const to_date = $('#to_date').val();
+  const project = $('#project_filter').val();
+
+  frappe.call({
+    method: "phamos.api.get_timesheets",
+    args: {
+      from_date,
+      to_date,
+      project,
+      offset: 0,
+      limit: 10000  // high limit to get all data
+    },
+    callback: function (r) {
+      if (r.message && r.message.timesheets) {
+        processDataForGraph(r.message.timesheets);
+      }
+    }
+  });
+}
+/////////////////////////////
+function load_graph_data() {
+  const from_date = $('#from_date').val();
+  const to_date = $('#to_date').val();
+  const project = $('#project_filter').val();
+
+  frappe.call({
+    method: "phamos.api.get_graph_data",
+    args: { from_date, to_date, project },
+    callback: function (r) {
+      if (r.message) {
+        loadAndRenderGraph(r.message);
+      }
+    }
+  });
+}
+
+/////////////////////////////////////
+loadAndRenderGraph();
+
+


### PR DESCRIPTION

\`## Description

Added graph in the **Customer Timesheet Portal** which shows points/data on a weekly basis.
**Key changes:**

- **Html file:** Added  div for the graph
- **Py file:** Get data from the tabTimesheet.
- **js file:** get a chart from **highcharts** and make it weekly basis which means weeks start on monday and ends on sunday.
- Also filter end_date, start_date and project are applicable.

**Related issue(s)/ticket(s):**
Issue: Implementing Dashboard with graph
Parent Issue : https://git.phamos.eu/phamos/phamos/-/issues/191


**Testing done:**
Working fine on local machine

**Screenshots & GIFs (if applicable):**
![Peek 2025-06-04 11-31](https://github.com/user-attachments/assets/b31c3a25-33d1-485a-a6f6-d0ceeeb6dbd3)

