### PR TITLE
Updating of status options (#172) & Issue resolved

### DIFF
--- a/phamos/patches.txt
+++ b/phamos/patches.txt
@@ -2,3 +2,5 @@ phamos.patches.v1_0.add_custom_fields_for_employee #1235
 phamos.patches.v1_0.add_property_for_timesheet_record #12334567
 phamos.patches.v1_0.add_custom_fields_for_project #1234567890
 phamos.patches.v1_0.add_nav_bar_item
+phamos.patches.v1_0.set_implementation_status
+phamos.patches.v1_0.updated_maturity_levels

--- a/phamos/patches/v1_0/set_implementation_status.py
+++ b/phamos/patches/v1_0/set_implementation_status.py
@@ -1,0 +1,7 @@
+import frappe
+
+def execute():
+    frappe.db.sql("""
+        UPDATE `tabImplementation`
+        SET status = 'Open'
+    """)

--- a/phamos/patches/v1_0/updated_maturity_levels.py
+++ b/phamos/patches/v1_0/updated_maturity_levels.py
@@ -1,0 +1,21 @@
+import frappe
+
+def execute():
+    old_to_new_levels = {
+        "1 - Start der Implementierung, keine Vorerfahrung, noch kein": "1 - Inception Phase. Early Implementation, no previous Frappe experience",
+        "2 - Poweruser kann sich orientieren,": "2 - Initial Development Phase. Initial development work, Power user can navigate system",
+        "3 - Live-Betrieb, Erste Module sind im Einsatz,": "3 - Development Phase. Development process understood, first modules customized",
+        "4 - Erste Module abgeschlossen, Entwicklungsprozesse in der Tiefe verstanden,": "4 - Go Live Phase. Go Live, first modules in use with real life data",
+        "5 - Quasi-abgeschlossen, System ist implementiert, Viele geschulte Anwender, hoher Automatisierungsgrad,": "5 - Live Development Phase. Ongoing development in parallel to system in daily use with live data"
+    }
+
+    for old, new in old_to_new_levels.items():
+        frappe.db.set_value(
+            "Implementation",
+            {"maturity_level": old},
+            "maturity_level",
+            new,
+            update_modified=False
+        )
+
+    frappe.db.commit()

--- a/phamos/phamos/doctype/implementation/implementation.json
+++ b/phamos/phamos/doctype/implementation/implementation.json
@@ -98,7 +98,7 @@
    "in_preview": 1,
    "in_standard_filter": 1,
    "label": "Maturity Level",
-   "options": "1 - Early Implementation, no previous Frappe experience\n2 - Initial development work, Poweruser can navigate system\n3 - Development process understood, first modules customized\n4 - Go Live, first modules in use with real life data\n5 - Ongoing development in parallel to system in daily use with live data\n6 - System in daily use, development work limited to customer support"
+   "options": "1 - Inception Phase. Early Implementation, no previous Frappe experience\n2 - Initial Development Phase. Initial development work, Power user can navigate system\n3 - Development Phase. Development process understood, first modules customized\n4 - Go Live Phase. Go Live, first modules in use with real life data\n5 - Live Development Phase. Ongoing development in parallel to system in daily use with live data\n6 - Support Phase. System in daily use, development work limited to customer support"
   },
   {
    "fieldname": "forecast",
@@ -320,7 +320,7 @@
    "link_fieldname": "custom_implementation"
   }
  ],
- "modified": "2025-05-29 15:58:52.889513",
+ "modified": "2025-06-16 11:43:21.246206",
  "modified_by": "Administrator",
  "module": "Phamos",
  "name": "Implementation",
@@ -340,6 +340,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "search_fields": "account_manager",
  "sort_field": "modified",
  "sort_order": "DESC",

--- a/phamos/phamos/doctype/implementation/implementation.py
+++ b/phamos/phamos/doctype/implementation/implementation.py
@@ -104,14 +104,12 @@ class Implementation(Document):
 				if d.date == today():
 					d.status = self.status
 					d.maturity_level = self.maturity_level
-					d.mood = self.mood
 					d.forecast = self.forecast
 				else:
 					self.append("status_updates", {
 						"date": today(),
 						"status":self.status,
 						"maturity_level": self.maturity_level,
-						"mood": self.mood,
 						"forecast": self.forecast
 					})
 		else:
@@ -119,7 +117,6 @@ class Implementation(Document):
 				"date": today(),
 				"status":self.status,
 				"maturity_level": self.maturity_level,
-				"mood": self.mood,
 				"forecast": self.forecast
 			})
 

--- a/phamos/phamos/doctype/status_information/status_information.json
+++ b/phamos/phamos/doctype/status_information/status_information.json
@@ -7,12 +7,11 @@
  "engine": "InnoDB",
  "field_order": [
   "date",
-  "mood",
-  "status",
+  "status_statement",
   "column_break_vlth",
   "maturity_level",
   "forecast",
-  "test"
+  "trend"
  ],
  "fields": [
   {
@@ -24,21 +23,6 @@
    "width": "20%"
   },
   {
-   "fieldname": "mood",
-   "fieldtype": "Select",
-   "in_list_view": 1,
-   "label": "Mood",
-   "options": "1\n2\n3\n4\n5",
-   "width": "10%"
-  },
-  {
-   "fieldname": "status",
-   "fieldtype": "Small Text",
-   "label": "Status",
-   "max_height": "200px",
-   "width": "50%"
-  },
-  {
    "fieldname": "column_break_vlth",
    "fieldtype": "Column Break"
   },
@@ -47,32 +31,41 @@
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "Maturity Level",
-   "options": "\n1 - Start der Implementierung, keine Vorerfahrung, noch kein\n2 - Poweruser kann sich orientieren,\n3 - Live-Betrieb, Erste Module sind im Einsatz,\n4 - Erste Module abgeschlossen, Entwicklungsprozesse in der Tiefe verstanden,\n5 - Quasi-abgeschlossen, System ist implementiert, Viele geschulte Anwender, hoher Automatisierungsgrad,",
+   "options": "1 - Inception Phase. Early Implementation, no previous Frappe experience\n2 - Initial Development Phase. Initial development work, Power user can navigate system\n3 - Development Phase. Development process understood, first modules customized\n4 - Go Live Phase. Go Live, first modules in use with real life data\n5 - Live Development Phase. Ongoing development in parallel to system in daily use with live data\n6 - Support Phase. System in daily use, development work limited to customer support",
    "width": "10%"
   },
   {
    "fieldname": "forecast",
    "fieldtype": "Select",
    "in_list_view": 1,
-   "label": "Forecast",
+   "label": "Implementation Status",
    "options": "1 \u2600\ufe0f - alles gut. Kunde happy, keine Gefahren (deadlines, Erwartung an Stunden etc) in sicht\n2 \ud83c\udf24\ufe0f - zu viele neue Issues, feedback langsam\n3 \u2601\ufe0f - weekly findet nicht jede Woche statt, Kundenprojektmanager schwer zu erreichen,\n4 \ud83c\udf27\ufe0f - Anforderungen \u00e4ndern sich sehr h\u00e4ufig, Weeklies werden nicht wahrgenommen, kunde antwortet auf Mails nicht\n5 \u26c8\ufe0f - Kunde zahlt Rechnungen nicht, Kunde hat keine Gedult",
    "width": "10%"
   },
   {
-   "fieldname": "test",
-   "fieldtype": "Data",
-   "label": "Test"
+   "fieldname": "trend",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "label": "Trend",
+   "options": "Improving\nStable\nDeclining"
+  },
+  {
+   "fieldname": "status_statement",
+   "fieldtype": "Small Text",
+   "in_list_view": 1,
+   "label": "Status Statement"
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-05-08 07:00:45.246742",
+ "modified": "2025-06-16 08:59:47.234094",
  "modified_by": "Administrator",
  "module": "Phamos",
  "name": "Status Information",
  "owner": "Administrator",
  "permissions": [],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": []


### PR DESCRIPTION

\`## Description

Updation in maturity levels and other fields in Implementation doctype. Also removed issue after deleting "mood" field.


**Key changes:**

* The mood field was removed in the "Details" and "Status History" tab.
* "Forecast" (in history tab) changed to "Implementation Status"
* "Trend" column added to history tab
* "Status Statement" column added to history tab
* Updated Maturity Level.
* Also Write a Patch to update the previous Maturity Level/ set implementation status to open.
* Remove error coming on saving implementation after deleting "mood" field

**Related issue(s)/ticket(s):**
Issue: Updating of status options (#172)
Parent Issue: phamos/phamos#172

**Testing done:**
Tested on local system found issue after deleting mood field but now it is working fine.

**Screenshots & GIFs (if applicable):**
![image](https://github.com/user-attachments/assets/40394831-5943-47ad-945f-08dd5c389857)
![image](https://github.com/user-attachments/assets/6b40981c-c1fe-48d9-9e8e-b5f17b3604c8)

